### PR TITLE
Assign LED2 to PB2 for Generic variant.

### DIFF
--- a/variants/GD32F303CC_GENERIC/variant.h
+++ b/variants/GD32F303CC_GENERIC/variant.h
@@ -79,6 +79,7 @@ extern "C" {
 /* LED definitions */
 #define LED_BUILTIN             PC13
 #define LED_GREEN               PC13
+#define LED2                    PB2
 
 /* user keys definitions */
 #define KEY0                    PB10


### PR DESCRIPTION
This allows the Blink example to compile and work on the BluePill
clone.