### PR TITLE
FlashStorage & EEPROM libraries

### DIFF
--- a/libraries/EEPROM/examples/eeprom_read_write/eeprom_read_write.ino
+++ b/libraries/EEPROM/examples/eeprom_read_write/eeprom_read_write.ino
@@ -1,0 +1,110 @@
+#include <Arduino.h>
+#include <EEPROM.h>
+
+struct MyObject
+{
+    float field1;
+    byte field2;
+    char name[10];
+};
+
+void secondTest();
+
+void setup()
+{
+    Serial.begin(115200);
+    delay(1000);
+    Serial.println("Starting EEPROM test!");
+
+    EEPROM.begin();
+    //erase.
+    Serial.println("Erasing EEPROM beforehand.");
+    for (size_t i = 0; i < sizeof(float) + sizeof(MyObject); i++)
+    {
+        EEPROM.write(i, 0xff);
+    }
+    EEPROM.commit();
+
+    float f = 123.456f; //Variable to store in EEPROM.
+    int eeAddress = 0;  //Location we want the data to be put.
+
+    //One simple call, with the address first and the object second.
+    EEPROM.put(eeAddress, f);
+
+    Serial.println("Written float data type! (value = " + String(f) + ")");
+
+    /** Put is designed for use with custom structures also. **/
+
+    //Data to store.
+    MyObject customVar = {
+        3.14f,
+        65,
+        "Working!"
+    };
+
+    eeAddress += sizeof(float); //Move address to the next byte after float 'f'.
+
+    EEPROM.put(eeAddress, customVar);
+    unsigned long micros_start = micros();
+    EEPROM.commit();
+    unsigned long micros_end = micros();
+
+    Serial.println("Written custom data type in " + String(micros_end - micros_start) + " microseconds!");
+    Serial.println("Now retrieving values.");
+
+    secondTest();
+}
+
+void secondTest()
+{
+    Serial.print("Read float from EEPROM: ");
+    float f = 0.00f;   //Variable to store data read from EEPROM.
+    int eeAddress = 0; //EEPROM address to start reading from
+
+    //Get the float data from the EEPROM at position 'eeAddress'
+    EEPROM.get(eeAddress, f);
+    Serial.println(f, 3); //This may print 'ovf, nan' if the data inside the EEPROM is not a valid float.
+
+    eeAddress = sizeof(float); //Move address to the next byte after float 'f'.
+
+    MyObject customVar; //Variable to store custom object read from EEPROM.
+    EEPROM.get(eeAddress, customVar);
+
+    Serial.println("Read custom object from EEPROM: ");
+    Serial.println(customVar.field1);
+    Serial.println(customVar.field2);
+    Serial.println(customVar.name);
+
+    if (strcmp(customVar.name, "Working!") == 0)
+    {
+        Serial.println("== Test passed: Writing + reading string field ==");
+        /* yes, exact float compare is wanted -- must be equal to what we wrote*/
+        if (customVar.field1 == 3.14f)
+        {
+            Serial.println("== Test passed: Writing + reading float field ==");
+            if (customVar.field2 == 65)
+            {
+                Serial.println("== Test passed: Writing + reading int field ==");
+                Serial.println("=== ALL TESTS PASSED ===");
+            }
+            else
+            {
+                Serial.println("== Test failed: Retrived not the same int ==");
+            }
+        }
+        else
+        {
+            Serial.println("== Test failed: Retrived not the same float ==");
+        }
+    }
+    else
+    {
+        Serial.println("== Test failed: Retrived not the same string ==");
+    }
+}
+
+void loop()
+{
+    Serial.println("Test done.");
+    delay(20000);
+}

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -1,0 +1,8 @@
+name=EEPROM
+version=0.1.0
+author=Keyboard.io, Inc.
+maintainer=Keyboard.io, Inc.
+sentence=EEPROM emulation layer for GD32.
+paragraph=
+category=Data Storage
+architectures=gd32

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -1,0 +1,38 @@
+/* -*- mode: c++ -*-
+ * Copyright (c) 2021  Keyboard.io, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FlashStorage.h"
+#include "FlashAsEEPROM.h"
+
+#ifndef EEPROM_EMULATION_SIZE
+#define EEPROM_EMULATION_SIZE 4096
+#endif
+
+static EEPROMClass<EEPROM_EMULATION_SIZE> EEPROM;

--- a/libraries/FlashStorage/README.md
+++ b/libraries/FlashStorage/README.md
@@ -1,0 +1,28 @@
+# FlashStorage
+
+This is a library that implements a way to read and write data from and to
+flash, from within the running program.
+
+## Design decisions
+
+There are different ways to do that, with different trade-offs. The goal during
+the design of this library was simplicity, and to fulfill the particular goals
+of the Kaleidoscope firmware. One of those goals is to make it easy to work with
+the storage, even when firmware is flashed frequently.
+
+For this reason, the storage defaults to being at the end of the flash, for
+which we can reserve space externally, and prevent accidentally overwriting it
+with program code. This way, when flashing new firmware, the storage area is not
+destroyed.
+
+It is still possible to have multiple storage areas, as `FlashStorage` allows
+specifying both a size and an end address, but care must be taken to not overlap
+with program code.
+
+## FlashAsEEPROM
+
+For practical reasons, the library includes a `FlashAsEEPROM.h` header, a class
+that implements an Arduino-esque EEPROM emulation layer on top of
+`FlashStorage`. The header does not export an `EEPROM` instance object, that's
+what the `EEPROM` library does. A separate library, for practical and
+convenience reasons.

--- a/libraries/FlashStorage/library.properties
+++ b/libraries/FlashStorage/library.properties
@@ -1,0 +1,8 @@
+name=FlashStorage
+version=0.1.0
+author=Keyboard.io, Inc.
+maintainer=Keyboard.io, Inc.
+sentence=The FlashStorage library aims to provide a convenient way to store and retrieve user's data using the non-volatile flash memory of microcontrollers.
+paragraph=
+category=Data Storage
+architectures=gd32

--- a/libraries/FlashStorage/src/FlashAsEEPROM.h
+++ b/libraries/FlashStorage/src/FlashAsEEPROM.h
@@ -44,6 +44,7 @@ class EEPROMClass {
   template<typename T>
   const T& put(uint32_t offset, const T& t) {
     storage_.write(offset, (const uint8_t *)&t, sizeof(T));
+    return t;
   }
 
   uint8_t read(uint32_t offset) {

--- a/libraries/FlashStorage/src/FlashAsEEPROM.h
+++ b/libraries/FlashStorage/src/FlashAsEEPROM.h
@@ -59,6 +59,10 @@ class EEPROMClass {
     write(offset, val);
   }
 
+  void commit() {
+    storage_.commit();
+  }
+
   void begin() {
     storage_.begin();
   }

--- a/libraries/FlashStorage/src/FlashAsEEPROM.h
+++ b/libraries/FlashStorage/src/FlashAsEEPROM.h
@@ -1,0 +1,68 @@
+/* -*- mode: c++ -*-
+ * Copyright (c) 2021  Keyboard.io, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FlashStorage.h"
+
+template <uint32_t _size>
+class EEPROMClass {
+ private:
+  FlashStorage<_size> storage_;
+
+ public:
+  template<typename T>
+  T& get(uint32_t offset, T& t) {
+    storage_.read(offset, (uint8_t *)&t, sizeof(T));
+    return t;
+  }
+  template<typename T>
+  const T& put(uint32_t offset, const T& t) {
+    storage_.write(offset, (const uint8_t *)&t, sizeof(T));
+  }
+
+  uint8_t read(uint32_t offset) {
+    uint8_t val;
+    storage_.read(offset, &val, sizeof(val));
+    return val;
+  }
+  void write(uint32_t offset, uint8_t val) {
+    storage_.write(offset, (uint8_t *)&val, sizeof(val));
+  }
+  void update(uint32_t offset, uint8_t val) {
+    write(offset, val);
+  }
+
+  void begin() {
+    storage_.begin();
+  }
+
+  uint32_t length() {
+    return _size;
+  }
+};

--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -58,7 +58,7 @@ class FlashStorage {
     }
   }
 
-  const uint32_t length() {
+  uint32_t length() {
     return _storage_size;
   }
 
@@ -71,12 +71,12 @@ class FlashStorage {
     if (offset > _storage_size || (data_size > (_storage_size - offset)))
       return;
 
-    for (auto i = 0; i < data_size; i++) {
+    for (uint32_t i = 0; i < data_size; i++) {
       data[i] = buffer_[i + offset];
     }
   }
 
-  void write(uint32_t offset, uint8_t *data, uint32_t data_size) {
+  void write(uint32_t offset, const uint8_t *data, uint32_t data_size) {
     // If we're out of bounds, or try to write too much, bail out.
     if (offset > _storage_size || data_size > _storage_size)
       return;

--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -53,7 +53,7 @@ class FlashStorage {
     fmc_unlock();
 
     uint8_t *src = (uint8_t *)data_area_start;
-    for (auto i = 0; i < _storage_size; i++) {
+    for (uint32_t i = 0; i < _storage_size; i++) {
       buffer_[i] = src[i];
     }
   }

--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -1,0 +1,106 @@
+/* -*- mode: c++ -*-
+ * Copyright (c) 2020  GigaDevice Semiconductor Inc.
+ *               2021  Keyboard.io, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+template <uint32_t _storage_size,
+          uint32_t _fmc_end = ARDUINO_UPLOAD_MAXIMUM_SIZE>
+class FlashStorage {
+ private:
+  uint8_t buffer_[_storage_size];
+  static constexpr uint32_t fmc_base_address = 0x08000000;
+  static constexpr uint32_t bank0_end = fmc_base_address + 512 * 1024 - 1;
+  static constexpr uint32_t fmc_end_address = fmc_base_address + _fmc_end;
+  static constexpr uint32_t data_area_start = fmc_end_address - _storage_size;
+
+  uint16_t pageSizeForAddress(uint32_t addr) {
+    if (addr > bank0_end)
+      return 4096;
+    else
+      return 2048;
+  }
+
+ public:
+  void begin() {
+    fmc_unlock();
+
+    uint8_t *src = (uint8_t *)data_area_start;
+    for (auto i = 0; i < _storage_size; i++) {
+      buffer_[i] = src[i];
+    }
+  }
+
+  const uint32_t length() {
+    return _storage_size;
+  }
+
+  void read(uint32_t offset, uint8_t *data, uint32_t data_size) {
+    // We always read from the buffer, as that's the most up-to-date. Flash is
+    // lagging behind until we commit(), but we may want to read before doing
+    // so.
+
+    // If we're out of bounds, or try to read too much, bail out.
+    if (offset > _storage_size || (data_size > (_storage_size - offset)))
+      return;
+
+    for (auto i = 0; i < data_size; i++) {
+      data[i] = buffer_[i + offset];
+    }
+  }
+
+  void write(uint32_t offset, uint8_t *data, uint32_t data_size) {
+    // If we're out of bounds, or try to write too much, bail out.
+    if (offset > _storage_size || data_size > _storage_size)
+      return;
+
+    for (uint32_t i = 0; i < data_size; i++) {
+      buffer_[offset + i] = data[i];
+    }
+  }
+
+  void commit() {
+    uint32_t address = data_area_start;
+    uint32_t *ptrs = (uint32_t *)buffer_;
+
+    do {
+      uint16_t page_size = pageSizeForAddress(address);
+      fmc_page_erase(address);
+
+      uint32_t word_count = page_size / 4;
+      uint32_t i = 0;
+
+      do {
+        fmc_word_program(address, *ptrs++);
+        address += 4U;
+      } while (++i < word_count);
+    } while (address < fmc_end_address);
+  }
+};

--- a/platform.txt
+++ b/platform.txt
@@ -4,7 +4,7 @@ name=GD32 ARM Boards
 version=1.0.0
 
 #compile variables
-##compile Include 
+##compile Include
 compiler.gd.extra_include= "-I{build.source.path}" "-I{build.core.path}/api/deprecated-avr-comp" "-I{build.core.path}/api/deprecated" "-I{build.core.path}/gd32" "-I{build.core.path}/gd32/Source" "-I{build.system.path}/startup" "-I{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-I{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-I{build.system.path}/{build.series}_firmware/CMSIS" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
 
 ## compile warning
@@ -25,7 +25,7 @@ compiler.elf2hex.cmd=arm-none-eabi-objcopy
 compiler.size.cmd=arm-none-eabi-size
 ##compile flags
 compiler.libraries.ldflags=
-compiler.extra_flags=-mcpu={build.mcu} {build.flags.fp} -mthumb 
+compiler.extra_flags=-mcpu={build.mcu} {build.flags.fp} -mthumb
 compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.gd.extra_include}
 compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -g3 -T -nostdlib --param max-inline-insns-single=500 -MMD {compiler.gd.extra_include}
 compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -g3 -T -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -fno-use-cxa-atexit -MMD {compiler.gd.extra_include}
@@ -55,7 +55,7 @@ build.bootloader_flags=-DVECT_TAB_OFFSET={build.flash_offset}
 build.ldscript=ldscript.ld
 
 ## Build information's flag
-build.info.flags=-D{build.series} -D{build.product_line} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DBOARD_NAME="{build.board}"
+build.info.flags=-D{build.series} -D{build.product_line} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DBOARD_NAME="{build.board}" -DARDUINO_UPLOAD_MAXIMUM_SIZE={upload.maximum_size}
 
 ## Defaults config
 build.xSerial=
@@ -141,4 +141,3 @@ tools.dfu-util.cmd=dfu-util
 tools.dfu-util.upload.params.verbose=-d
 tools.dfu-util.upload.params.quiet=
 tools.dfu-util.upload.pattern="{path}/{cmd}" --device {upload.vid}:{upload.pid} -D "{build.path}/{build.project_name}.bin" -R {upload.options}
-

--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Extended and rewritten by Maximilian Gerhardt <maximilian.gerhardt@rub.de>
-# for GD32 core. 
+# for GD32 core.
 
 """
 Arduino
@@ -218,6 +218,7 @@ env.Append(
         "ARDUINO_ARCH_GD32",
         "ARDUINO_%s" % board_id,
         ("BOARD_NAME", '\\"%s\\"' % board_id),
+        ("ARDUINO_UPLOAD_MAXIMUM_SIZE", board_config.get("upload.maximum_size")),
     ],
     CPPPATH=[
         join(FRAMEWORK_DIR, "cores", "arduino", "api", "deprecated"),


### PR DESCRIPTION
This is a work-in-progress version of my attempt at a pair of FlashStorage & EEPROM libraries.

`FlashStorage` is a lower-level library that abstracts away (most of) the burden of storing and retrieving user data from flash. It simply provides a `read()` and a `write()` method, that handle all the pageing, erasing and updating and whatnot behind the scenes, so the end user doesn't have to care about the low level details.

`EEPROM` builds on top of that, and provides an Arduino-esque `EEPROMClass`, with an API similar to the AVR `EEPROM`. It's more limited than that, because only the basic functionality required for Kaleidoscope is implemented at this point (no C+11 iterators or array access at this point).

There are a few things I need to work out still, namely:
- [x] Sane defaults. At the moment, I copied some defaults from `05_USBD_MSC_internal_flash`. Ideally, we'd have those defaults come from `boards.txt`. The major things we need is the size of the storage, where it starts (or where it ends, which is more practical to store in boards.txt in our case), and the page size.
- [x] Make small operations more efficient. At the moment, _all_ reads and writes require a full page read/write, even if we could do with less. In case of Kaleidoscope, we quite often do much smaller reads and writes.

For reads, we can be _much_ more efficient, because we don't need any paging there. We just read N byes of data from an address, and done.

For writes, the most efficient way would be to copy the whole storage to RAM, and only write back on `commit()`. That'd make writes a lot more efficient, at the cost of ram. Another option would be to have a `prepareWrite()` function, that tells the library how much data we'll write, and where, so it'll prep that area in RAM, and write it all back in `commit()`. This, however, would require dynamic memory allocation. There's `fmc_word_reprogram()`, which should - judging by its comments - reprogram a word at an address without erase. We could use that for more efficient small writes, as we won't have to do full page erase + writes. However, any of these require more thought, and I'll postpone efficient writes 'till a follow-up PR instead. Lets get the very basic functionality working in this one first.

Meanwhile, I'm submitting this as a draft PR for comments, and perhaps ideas. The code has _not_ been tested on hardware yet, I've only done compile tests with this iteration. Once I got to the "test on hardware" stage, I'll report back too.