### PR TITLE
Switch our system includes to -isystem from -I

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -5,7 +5,7 @@ version=1.0.0
 
 #compile variables
 ##compile Include 
-compiler.gd.extra_include= "-I{build.source.path}" "-isystem{build.core.path}/api/deprecated-avr-comp" "-isystem{build.core.path}/api/deprecated" "-isystem{build.core.path}/gd32" "-isystem{build.core.path}/gd32/Source" "-isystem{build.system.path}/startup" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-isystem{build.system.path}/{build.series}_firmware/CMSIS" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
+compiler.gd.extra_include= "-I{build.source.path}" "-isystem{build.core.path}/api/deprecated-avr-comp" "-isystem{build.core.path}/api/deprecated" "-I{build.core.path}/gd32" "-I{build.core.path}/gd32/Source" "-isystem{build.system.path}/startup" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-isystem{build.system.path}/{build.series}_firmware/CMSIS" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
 
 ## compile warning
 compiler.warning_flags=-w

--- a/platform.txt
+++ b/platform.txt
@@ -5,7 +5,7 @@ version=1.0.0
 
 #compile variables
 ##compile Include 
-compiler.gd.extra_include= "-I{build.source.path}" "-I{build.core.path}/api/deprecated-avr-comp" "-I{build.core.path}/api/deprecated" "-I{build.core.path}/gd32" "-I{build.core.path}/gd32/Source" "-I{build.system.path}/startup" "-I{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-I{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-I{build.system.path}/{build.series}_firmware/CMSIS" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-I{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
+compiler.gd.extra_include= "-I{build.source.path}" "-isystem{build.core.path}/api/deprecated-avr-comp" "-isystem{build.core.path}/api/deprecated" "-isystem{build.core.path}/gd32" "-isystem{build.core.path}/gd32/Source" "-isystem{build.system.path}/startup" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-isystem{build.system.path}/{build.series}_firmware/CMSIS" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
 
 ## compile warning
 compiler.warning_flags=-w

--- a/platform.txt
+++ b/platform.txt
@@ -5,7 +5,7 @@ version=1.0.0
 
 #compile variables
 ##compile Include 
-compiler.gd.extra_include= "-I{build.source.path}" "-isystem{build.core.path}/api/deprecated-avr-comp" "-isystem{build.core.path}/api/deprecated" "-I{build.core.path}/gd32" "-I{build.core.path}/gd32/Source" "-isystem{build.system.path}/startup" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-isystem{build.system.path}/{build.series}_firmware/CMSIS" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
+compiler.gd.extra_include= "-I{build.source.path}" "-isystem{build.core.path}/api/deprecated-avr-comp" "-isystem{build.core.path}/api/deprecated" "-I{build.core.path}/gd32" "-isystem{build.system.path}/startup" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Source" "-isystem{build.system.path}/{build.series}_firmware/{build.series}_standard_peripheral/Include"  "-isystem{build.system.path}/{build.series}_firmware/CMSIS" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Include" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source/GCC" "-isystem{build.system.path}/{build.series}_firmware/CMSIS/GD/{build.series}/Source"
 
 ## compile warning
 compiler.warning_flags=-w


### PR DESCRIPTION
This causes GCC to treat them as system files and to not warn about
them, since we can't fix their coding style choices that -Wall -Wextra
hate