### PR TITLE
Rework the internals of our I2C library to make timeouts more configurable

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -528,6 +528,26 @@ i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t lengt
     return ret;
 }
 
+
+/** Check the I2C bus to see if it's busy
+ *
+ * @param obj    The I2C object
+ * @returns I2C_BUSY on timeout and I2C_OK otherwise
+ **/
+
+i2c_status_enum _i2c_busy_wait(i2c_t *obj)
+{
+
+    /* wait until I2C_FLAG_I2CBSY flag is reset */
+    uint32_t timeout = WIRE_I2C_FLAG_TIMEOUT_BUSY;
+    while ((i2c_flag_get(obj->i2c, I2C_FLAG_I2CBSY)) && (--timeout != 0));
+    if (0 == timeout) {
+        return I2C_BUSY;
+    }
+
+    return I2C_OK;
+}
+
 #ifdef I2C0
 /** This function handles I2C interrupt handler
  *

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -250,15 +250,6 @@ i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, 
         return I2C_BUSY;
     }
 
-    /* When size is 0, this is usually an I2C scan / ping to check if device is there and ready */
-    if (length == 0) {
-        ret = i2c_wait_standby_state(obj, address);
-    } else {
-        timeout = FLAG_TIMEOUT;
-        while ((i2c_flag_get(obj->i2c, I2C_FLAG_I2CBSY)) && (--timeout != 0));
-        if (0 == timeout) {
-            ret = I2C_BUSY;
-        }
     /* generate a START condition */
     i2c_start_on_bus(obj->i2c);
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -397,7 +397,11 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
 
         timeout = WIRE_I2C_FLAG_TIMEOUT_BYTE_RECEIVED;
         while ((!i2c_flag_get(obj->i2c, I2C_FLAG_RBNE)) && (--timeout != 0));
-        data[count] = i2c_data_receive(obj->i2c);
+        if (0 == timeout) {
+            ret = I2C_NACK_DATA;
+        } else {
+            data[count] = i2c_data_receive(obj->i2c);
+        };
     }
     /* if not sequential read, then send stop */
     if (stop) {

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -279,10 +279,17 @@ i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, 
         if (I2C_OK != ret) {
             break;
         }
-        /* if not sequential write, then send stop */
-        if (stop) {
-            i2c_stop(obj);
+        if (I2C_OK != i2c_byte_write(obj, data[count])) {
+            // If we didn't write the byte successfully,
+            // we really don't want to keep trying to write subsequent
+            // bytes
+
+            ret = I2C_NACK_DATA;
         }
+    }
+    /* if not sequential write, then send stop */
+    if (stop) {
+        i2c_stop(obj);
     }
     return ret;
 }

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -47,7 +47,6 @@ typedef enum {
 } internal_i2c_index_t;
 
 static struct i2c_s *obj_s_buf[I2C_NUM] = {NULL};
-#define BUSY_TIMEOUT  ((SystemCoreClock / obj_s->freq) * 2 * 10)
 
 #ifndef WIRE_I2C_FLAG_TIMEOUT
 #define FLAG_TIMEOUT  (0xF0000U)

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -249,25 +249,25 @@ i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, 
         /* generate a START condition */
         i2c_start_on_bus(obj->i2c);
 
-        /* ensure the i2c has been started successfully */
-        timeout = WIRE_I2C_FLAG_TIMEOUT_START;
-        while ((!i2c_flag_get(obj->i2c, I2C_FLAG_SBSEND)) && (--timeout != 0));
-        if (0 == timeout) {
-            ret = I2C_TIMEOUT;
-        }
+    /* ensure the i2c has been started successfully */
+    timeout = WIRE_I2C_FLAG_TIMEOUT_START;
+    while ((!i2c_flag_get(obj->i2c, I2C_FLAG_SBSEND)) && (--timeout != 0));
+    if (0 == timeout) {
+        return I2C_TIMEOUT;
+    }
 
-        /* send slave address */
-        i2c_master_addressing(obj->i2c, address, I2C_TRANSMITTER);
+    /* send slave address */
+    i2c_master_addressing(obj->i2c, address, I2C_TRANSMITTER);
 
-        /* wait until I2C_FLAG_ADDSEND flag is set */
-        timeout = WIRE_I2C_FLAG_TIMEOUT_ADDR_ACK;
-        while ((!i2c_flag_get(obj->i2c, I2C_FLAG_ADDSEND)) && (--timeout != 0));
-        if (0 == timeout) {
-            ret = I2C_NACK_ADDR;
-        }
+    /* wait until I2C_FLAG_ADDSEND flag is set */
+    timeout = WIRE_I2C_FLAG_TIMEOUT_ADDR_ACK;
+    while ((!i2c_flag_get(obj->i2c, I2C_FLAG_ADDSEND)) && (--timeout != 0));
+    if (0 == timeout) {
+        ret = I2C_NACK_ADDR;
+    }
 
-        /* clear ADDSEND */
-        i2c_flag_clear(obj->i2c, I2C_FLAG_ADDSEND);
+    /* clear ADDSEND */
+    i2c_flag_clear(obj->i2c, I2C_FLAG_ADDSEND);
 
         for (count = 0; count < length; count++) {
             if (1 != i2c_byte_write(obj, data[count])) {
@@ -357,6 +357,7 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
     i2c_master_addressing(obj->i2c, address, I2C_RECEIVER);
     timeout = WIRE_I2C_FLAG_TIMEOUT_ADDR_ACK;
     while ((!i2c_flag_get(obj->i2c, I2C_FLAG_ADDSEND)) && (--timeout != 0));
+
     if (0 == timeout) {
         ret = I2C_NACK_ADDR;
     }
@@ -369,6 +370,7 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
             timeout = WIRE_I2C_FLAG_TIMEOUT_DATA_ACK;
 
             while ((!i2c_flag_get(obj->i2c, I2C_FLAG_BTC)) && (--timeout != 0));
+
             if (0 == timeout) {
                 ret = I2C_NACK_DATA;
             }
@@ -378,6 +380,7 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
             timeout = WIRE_I2C_FLAG_TIMEOUT_DATA_ACK;
 
             while ((!i2c_flag_get(obj->i2c, I2C_FLAG_BTC)) && (--timeout != 0));
+
             if (0 == timeout) {
                 ret = I2C_NACK_DATA;
             }
@@ -388,7 +391,6 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
         while ((!i2c_flag_get(obj->i2c, I2C_FLAG_RBNE)) && (--timeout != 0));
         data[count] = i2c_data_receive(obj->i2c);
     }
-
     /* if not sequential read, then send stop */
     if (stop) {
         i2c_stop(obj);

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -229,6 +229,17 @@ i2c_status_enum  i2c_stop(i2c_t *obj)
 i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, uint16_t length,
                                     uint8_t stop)
 {
+
+
+    /* When size is 0, this is usually an I2C scan / ping to check if device is there and ready */
+    if (length == 0) {
+        return i2c_wait_standby_state(obj, address);
+    }
+
+    if (length > I2C_BUFFER_SIZE) {
+        return I2C_DATA_TOO_LONG;
+    }
+
     i2c_status_enum ret = I2C_OK;
     uint32_t timeout = 0;
     uint32_t count = 0;

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -468,15 +468,12 @@ i2c_status_enum i2c_wait_standby_state(i2c_t *obj, uint8_t address)
         status = I2C_NACK_ADDR;
     }
 
-    /* send a stop condition to I2C bus */
-    i2c_stop_on_bus(obj->i2c);
-    timeout = FLAG_TIMEOUT;
-    /* wait until the stop condition is finished */
-    while ((I2C_CTL0(obj->i2c) & 0x0200) && (--timeout != 0));
 
-    if (0 == timeout) {
-        status = I2C_TIMEOUT;
+    // On failure to send a stop, return the timeout
+    if (i2c_stop(obj) != I2C_OK) {
+        return I2C_TIMEOUT;
     }
+
     return status;
 }
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -259,8 +259,8 @@ i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, 
         if (0 == timeout) {
             ret = I2C_BUSY;
         }
-        /* generate a START condition */
-        i2c_start_on_bus(obj->i2c);
+    /* generate a START condition */
+    i2c_start_on_bus(obj->i2c);
 
     /* ensure the i2c has been started successfully */
     timeout = WIRE_I2C_FLAG_TIMEOUT_START;

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -371,6 +371,9 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
     i2c_flag_clear(obj->i2c, I2C_FLAG_ADDSEND);
 
     for (count = 0; count < length; count++) {
+        if (ret != I2C_OK) {
+            break;
+        }
         if (length > 2 && count == (uint32_t)length - 3) {
             timeout = WIRE_I2C_FLAG_TIMEOUT_DATA_ACK;
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -233,8 +233,10 @@ i2c_status_enum i2c_master_transmit(i2c_t *obj, uint8_t address, uint8_t *data, 
     uint32_t timeout = 0;
     uint32_t count = 0;
 
-    if (length > I2C_BUFFER_SIZE) {
-        ret = I2C_DATA_TOO_LONG;
+
+
+    if (I2C_BUSY == _i2c_busy_wait(obj)) {
+        return I2C_BUSY;
     }
 
     /* When size is 0, this is usually an I2C scan / ping to check if device is there and ready */
@@ -326,12 +328,12 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
     uint32_t timeout = 0;
     uint32_t count = 0;
 
-    timeout = FLAG_TIMEOUT;
-
-    while ((i2c_flag_get(obj->i2c, I2C_FLAG_I2CBSY)) && (--timeout != 0));
-    if (0 == timeout) {
-        ret = I2C_BUSY;
+    if (I2C_BUSY == _i2c_busy_wait(obj)) {
+        return I2C_BUSY;
     }
+
+
+
     if (1 == length) {
         /* disable acknowledge */
         i2c_ack_config(obj->i2c, I2C_ACK_DISABLE);
@@ -410,11 +412,9 @@ i2c_status_enum i2c_wait_standby_state(i2c_t *obj, uint8_t address)
     i2c_status_enum status = I2C_OK;
     uint32_t timeout;
 
-    /* wait until I2C_FLAG_I2CBSY flag is reset */
-    timeout = FLAG_TIMEOUT;
-    while ((i2c_flag_get(obj->i2c, I2C_FLAG_I2CBSY)) && (--timeout != 0));
-    if (0 == timeout) {
-        status = I2C_BUSY;
+
+    if (I2C_BUSY == _i2c_busy_wait(obj)) {
+        return I2C_BUSY;
     }
 
     /* send a start condition to I2C bus */

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -354,7 +354,7 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
     i2c_start_on_bus(obj->i2c);
     while ((!i2c_flag_get(obj->i2c, I2C_FLAG_SBSEND)) && (--timeout != 0));
     if (0 == timeout) {
-        ret = I2C_TIMEOUT;
+        return I2C_TIMEOUT;
     }
     /* send slave address */
     i2c_master_addressing(obj->i2c, address, I2C_RECEIVER);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -94,6 +94,8 @@ void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void));
 i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t size);
 /* set I2C clock speed */
 void i2c_set_clock(i2c_t *obj, uint32_t clock_hz);
+/* Check to see if the I2C bus is busy */
+i2c_status_enum _i2c_busy_wait(i2c_t *obj);
 
 
 


### PR DESCRIPTION
Along the way, I caught a couple of logic errors

Timeouts are now much more configurable and we bail a lot faster on error conditions.