### PR TITLE
Bjc/usb fixes

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -507,7 +507,6 @@ int USBCore_::recvControl(void* data, int len)
                 rxWaiting = false;
             }
         }
-        rxWaiting = true;
         read += USBCore().usbDev().drv_handler->ep_read((uint8_t *)data+read, 0, (uint8_t)EP_BUF_SNG);
     }
     assert(read == len);

--- a/extra/gd32usb-test/Makefile
+++ b/extra/gd32usb-test/Makefile
@@ -47,4 +47,4 @@ serial:
 #	ssh -t raichu screen $(SERIAL) 115200
 
 etags:
-	cd ../.. && find . -name '*.[ch]' -o \( -name '*.cpp' -o -name '*.ino' \) -print | grep -v usbfs | etags -
+	cd ../.. && find cores libraries extra/gd32usb-test system/startup system/GD32F30x_firmware -name '*.[ch]' -o \( -name '*.cpp' -o -name '*.ino' \) | grep -v usbfs | etags -

--- a/extra/gd32usb-test/Makefile
+++ b/extra/gd32usb-test/Makefile
@@ -1,4 +1,4 @@
-FQBN = dev:gd32:gd_generic_f30x
+FQBN = dev:gd32:gd_generic_gd32f30x
 GCC_PREFIX = /usr
 # TODO: arduino-cli --upload still doesn’t find openocd for some
 # reason. Maybe the method above is wrong?


### PR DESCRIPTION
This patch fixes a hang when the device is reset by the host mid-transmission. It's currently incomplete, as it only doesn't deal with a reset when receiving data.

However, this is being used for Keyboardio in this form, and I think it's probably better for it to go in now, even though it's incomplete, so that it doesn't get lost while a better fix is prepared.