### PR TITLE
Make all hardware serial ports accessible

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -30,33 +30,43 @@
 // SerialEvent functions are weak, so when the user doesn't define them,
 // the linker just sets their address to 0 (which is checked below).
 // The Serialx_available is just a wrapper around Serialx.available(),
-// but we can refer to it weakly so we don't pull in the entire
+// but implemented more low level so that we don't have a reference to Serialx.
+// also we can refer to it weakly so we don't pull in the entire
 // HardwareSerial instance if the user doesn't also refer to it.
 
+extern struct serial_s *obj_s_buf[UART_NUM];
+
+int HardwareSerial::availableSerialN(unsigned n)
+{
+    // copy of the HardwareSerial::available function but more direct.
+    if (n >= UART_NUM)
+        return 0;
+    auto _serial = obj_s_buf[n];
+    return ((unsigned int)(SERIAL_RX_BUFFER_SIZE + _serial->rx_head - _serial->rx_tail)) %
+           SERIAL_RX_BUFFER_SIZE;
+}
+
 #if defined(HAVE_HWSERIAL1)
-HardwareSerial Serial1(RX0, TX0, 0);
 void serialEvent1() __attribute__((weak));
 bool Serial1_available()
 {
-    return Serial1.available() > 0;
+    return HardwareSerial::availableSerialN(0) > 0;
 }
 #endif
 
 #if defined(HAVE_HWSERIAL2)
-HardwareSerial Serial2(RX1, TX1, 1);
 void serialEvent2() __attribute__((weak));
 bool Serial2_available()
 {
-    return Serial2.available() > 0;
+    return HardwareSerial::availableSerialN(1) > 0;
 }
 #endif
 
 #if defined(HAVE_HWSERIAL3)
-HardwareSerial Serial3(RX2, TX2, 2);
 void serialEvent3() __attribute__((weak));
 bool Serial3_available()
 {
-    return Serial3.available() > 0;
+    return HardwareSerial::availableSerialN(2) > 0;
 }
 #endif
 
@@ -65,7 +75,7 @@ HardwareSerial Serial4(RX3, TX3, 3);
 void serialEvent4() __attribute__((weak));
 bool Serial4_available()
 {
-    return Serial4.available() > 0;
+    return HardwareSerial::availableSerialN(3) > 0;
 }
 #endif
 
@@ -74,7 +84,7 @@ HardwareSerial Serial5(RX4, TX4, 4);
 void serialEvent5() __attribute__((weak));
 bool Serial5_available()
 {
-    return Serial5.available() > 0;
+    return HardwareSerial::availableSerialN(4) > 0;
 }
 #endif
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -135,6 +135,9 @@ class HardwareSerial : public Stream
         static void _rx_complete_irq(serial_t *obj);
         static void _tx_complete_irq(serial_t *obj);
 
+        // helper func for linker
+        static int availableSerialN(unsigned n);
+
     private:
 
 };
@@ -144,46 +147,45 @@ class HardwareSerial : public Stream
  * ‘Serial1’.
  */
 
+#ifndef DEFAULT_HWSERIAL_INSTANCE 
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
+
 /* Macro-define Serial to actual serial instance. We don't yet have a selection mechanism, use the first one. */
 #if !defined(USBD_USE_CDC)
 #if !defined(Serial)
-#if defined(USE_USART0_SERIAL)
+#if DEFAULT_HWSERIAL_INSTANCE == 1
 #define Serial Serial1
-#elif defined(USE_USART1_SERIAL)
+#elif DEFAULT_HWSERIAL_INSTANCE == 2
 #define Serial Serial2
-#elif defined(USE_USART2_SERIAL)
+#elif DEFAULT_HWSERIAL_INSTANCE == 3
 #define Serial Serial3
-#elif defined(USE_USART3_SERIAL)
+#elif DEFAULT_HWSERIAL_INSTANCE == 4
 #define Serial Serial4
-#elif defined(USE_USART4_SERIAL)
+#elif DEFAULT_HWSERIAL_INSTANCE == 5
 #define Serial Serial5
-#endif /* USE_USART1_SERIAL */
+#endif /* DEFAULT_HWSERIAL_IS_USART1 */
 #endif /* Serial */
 #endif /* USBD_USE_CDC */
 
-#if defined(USE_USART0_SERIAL)
+#if defined(HAVE_HWSERIAL1)
 extern HardwareSerial Serial1;
-#define HAVE_HWSERIAL1
 #endif
 
-#if defined(USE_USART1_SERIAL)
+#if defined(HAVE_HWSERIAL2)
 extern HardwareSerial Serial2;
-#define HAVE_HWSERIAL2
 #endif
 
-#if defined(USE_USART2_SERIAL)
+#if defined(HAVE_HWSERIAL3)
 extern HardwareSerial Serial3;
-#define HAVE_HWSERIAL3
 #endif
 
-#if defined(USE_USART3_SERIAL)
+#if defined(HAVE_HWSERIAL4)
 extern HardwareSerial Serial4;
-#define HAVE_HWSERIAL4
 #endif
 
-#if defined(USE_USART4_SERIAL)
+#if defined(HAVE_HWSERIAL5)
 extern HardwareSerial Serial5;
-#define HAVE_HWSERIAL5
 #endif
 
 extern void serialEventRun(void) __attribute__((weak));

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -164,7 +164,7 @@ class HardwareSerial : public Stream
 #define Serial Serial4
 #elif DEFAULT_HWSERIAL_INSTANCE == 5
 #define Serial Serial5
-#endif /* DEFAULT_HWSERIAL_IS_USART1 */
+#endif /* DEFAULT_HWSERIAL_INSTANCE */
 #endif /* Serial */
 #endif /* USBD_USE_CDC */
 

--- a/cores/arduino/HardwareSerial1.cpp
+++ b/cores/arduino/HardwareSerial1.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "HardwareSerial.h"
+
+// Place each serial in its own .cpp file so that the linker cleans it up
+// if the user sketch doesn't refer to it.
+// otherwise we pay the RAM for *all* serial objects.
+
+#if defined(HAVE_HWSERIAL1)
+HardwareSerial Serial1(RX0, TX0, 0);
+#endif

--- a/cores/arduino/HardwareSerial2.cpp
+++ b/cores/arduino/HardwareSerial2.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "HardwareSerial.h"
+
+// Place each serial in its own .cpp file so that the linker cleans it up
+// if the user sketch doesn't refer to it.
+// otherwise we pay the RAM for *all* serial objects.
+
+#if defined(HAVE_HWSERIAL2)
+HardwareSerial Serial2(RX1, TX1, 1);
+#endif

--- a/cores/arduino/HardwareSerial3.cpp
+++ b/cores/arduino/HardwareSerial3.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "HardwareSerial.h"
+
+// Place each serial in its own .cpp file so that the linker cleans it up
+// if the user sketch doesn't refer to it.
+// otherwise we pay the RAM for *all* serial objects.
+
+#if defined(HAVE_HWSERIAL3)
+HardwareSerial Serial3(RX2, TX2, 2);
+#endif

--- a/cores/arduino/HardwareSerial4.cpp
+++ b/cores/arduino/HardwareSerial4.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "HardwareSerial.h"
+
+// Place each serial in its own .cpp file so that the linker cleans it up
+// if the user sketch doesn't refer to it.
+// otherwise we pay the RAM for *all* serial objects.
+
+#if defined(HAVE_HWSERIAL4)
+HardwareSerial Serial4(RX3, TX3, 3);
+#endif

--- a/cores/arduino/HardwareSerial5.cpp
+++ b/cores/arduino/HardwareSerial5.cpp
@@ -1,0 +1,10 @@
+#include "Arduino.h"
+#include "HardwareSerial.h"
+
+// Place each serial in its own .cpp file so that the linker cleans it up
+// if the user sketch doesn't refer to it.
+// otherwise we pay the RAM for *all* serial objects.
+
+#if defined(HAVE_HWSERIAL5)
+HardwareSerial Serial5(RX4, TX4, 4);
+#endif

--- a/cores/arduino/gd32/pins_arduino.h
+++ b/cores/arduino/gd32/pins_arduino.h
@@ -56,6 +56,23 @@ static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 
 /* the PIN_SERIAL_TX/RX definitions point to the default Serial's pins */
+#if defined(DEFAULT_HWSERIAL_IS_USART0)
+#define PIN_SERIAL_RX       SERIAL0_RX
+#define PIN_SERIAL_TX       SERIAL0_TX
+#elif defined(DEFAULT_HWSERIAL_IS_USART1)
+#define PIN_SERIAL_RX       SERIAL1_RX
+#define PIN_SERIAL_TX       SERIAL1_TX
+#elif defined(DEFAULT_HWSERIAL_IS_USART2)
+#define PIN_SERIAL_RX       SERIAL2_RX
+#define PIN_SERIAL_TX       SERIAL2_TX
+#elif defined(DEFAULT_HWSERIAL_IS_USART3)
+#define PIN_SERIAL_RX       SERIAL3_RX
+#define PIN_SERIAL_TX       SERIAL3_TX
+#elif defined(DEFAULT_HWSERIAL_IS_USART4)
+#define PIN_SERIAL_RX       SERIAL4_RX
+#define PIN_SERIAL_TX       SERIAL4_TX
+#endif
+
 static const uint8_t TX = PIN_SERIAL_TX;
 static const uint8_t RX = PIN_SERIAL_RX;
 
@@ -73,6 +90,30 @@ static const uint8_t RX1 = SERIAL1_RX;
 
 #if defined(SERIAL1_TX)
 static const uint8_t TX1 = SERIAL1_TX;
+#endif
+
+#if defined(SERIAL2_RX)
+static const uint8_t RX2 = SERIAL2_RX;
+#endif
+
+#if defined(SERIAL2_TX)
+static const uint8_t TX2 = SERIAL2_TX;
+#endif
+
+#if defined(SERIAL3_RX)
+static const uint8_t RX3 = SERIAL3_RX;
+#endif
+
+#if defined(SERIAL3_TX)
+static const uint8_t TX3 = SERIAL3_TX;
+#endif
+
+#if defined(SERIAL4_RX)
+static const uint8_t RX4 = SERIAL4_RX;
+#endif
+
+#if defined(SERIAL4_TX)
+static const uint8_t TX4 = SERIAL4_TX;
 #endif
 
 /* configure analog pins */

--- a/cores/arduino/gd32/pins_arduino.h
+++ b/cores/arduino/gd32/pins_arduino.h
@@ -56,19 +56,19 @@ static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 
 /* the PIN_SERIAL_TX/RX definitions point to the default Serial's pins */
-#if defined(DEFAULT_HWSERIAL_IS_USART0)
+#if DEFAULT_HWSERIAL_INSTANCE == 1
 #define PIN_SERIAL_RX       SERIAL0_RX
 #define PIN_SERIAL_TX       SERIAL0_TX
-#elif defined(DEFAULT_HWSERIAL_IS_USART1)
+#elif DEFAULT_HWSERIAL_INSTANCE == 2
 #define PIN_SERIAL_RX       SERIAL1_RX
 #define PIN_SERIAL_TX       SERIAL1_TX
-#elif defined(DEFAULT_HWSERIAL_IS_USART2)
+#elif DEFAULT_HWSERIAL_INSTANCE == 3
 #define PIN_SERIAL_RX       SERIAL2_RX
 #define PIN_SERIAL_TX       SERIAL2_TX
-#elif defined(DEFAULT_HWSERIAL_IS_USART3)
+#elif DEFAULT_HWSERIAL_INSTANCE == 4
 #define PIN_SERIAL_RX       SERIAL3_RX
 #define PIN_SERIAL_TX       SERIAL3_TX
-#elif defined(DEFAULT_HWSERIAL_IS_USART4)
+#elif DEFAULT_HWSERIAL_INSTANCE == 5
 #define PIN_SERIAL_RX       SERIAL4_RX
 #define PIN_SERIAL_TX       SERIAL4_TX
 #endif

--- a/cores/arduino/gd32/uart.c
+++ b/cores/arduino/gd32/uart.c
@@ -46,26 +46,7 @@ OF SUCH DAMAGE.
 extern "C" {
 #endif
 
-typedef enum {
-#if defined(USART0)
-    UART0_INDEX,
-#endif
-#if defined(USART1)
-    UART1_INDEX,
-#endif
-#if defined(USART2)
-    UART2_INDEX,
-#endif
-#if defined(UART3)
-    UART3_INDEX,
-#endif
-#if defined(UART4)
-    UART4_INDEX,
-#endif
-    UART_NUM
-} int_uart_indexes_t;
-
-static struct serial_s *obj_s_buf[UART_NUM] = {NULL};
+struct serial_s *obj_s_buf[UART_NUM] = {NULL};
 static rcu_periph_enum usart_clk[UART_NUM]  = {
     RCU_USART0,
     RCU_USART1,
@@ -134,6 +115,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     p_obj->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
 
     /* enable UART peripheral clock */
+    /* TODO: This code makes no sense. It checks p_obj->index to set p_obj->index to its exact same value as before */
+    /* however, since p_obj->index was already previously set, this is no problem. */
     switch (p_obj->index) {
 #if defined(USART0)
         case UART0_INDEX:
@@ -755,11 +738,29 @@ void UART3_IRQHandler(void)
 }
 #endif
 
+#if defined(USART3)
+void USART3_IRQHandler(void)
+{
+    /* clear pending IRQ */
+    NVIC_ClearPendingIRQ(usart_irq_n[UART3_INDEX]);
+    usart_irq(obj_s_buf[UART3_INDEX]);
+}
+#endif
+
 /** This function handles UART4 interrupt handler
  *
  */
 #if defined(UART4)
 void UART4_IRQHandler(void)
+{
+    /* clear pending IRQ */
+    NVIC_ClearPendingIRQ(usart_irq_n[UART4_INDEX]);
+    usart_irq(obj_s_buf[UART4_INDEX]);
+}
+#endif
+
+#if defined(USART4)
+void USART4_IRQHandler(void)
 {
     /* clear pending IRQ */
     NVIC_ClearPendingIRQ(usart_irq_n[UART4_INDEX]);

--- a/cores/arduino/gd32/uart.h
+++ b/cores/arduino/gd32/uart.h
@@ -151,6 +151,25 @@ struct serial_s {
     void (*rx_callback)(serial_t *obj);
 };
 
+typedef enum {
+#if defined(USART0)
+    UART0_INDEX,
+#endif
+#if defined(USART1)
+    UART1_INDEX,
+#endif
+#if defined(USART2)
+    UART2_INDEX,
+#endif
+#if defined(UART3) || defined(USART3)
+    UART3_INDEX,
+#endif
+#if defined(UART4) || defined(USART4)
+    UART4_INDEX,
+#endif
+    UART_NUM
+} int_uart_indexes_t;
+
 /* Initialize the serial peripheral. It sets the default parameters for serial peripheral, and configures its specifieds pins. */
 void serial_init(serial_t *obj, PinName tx, PinName rx);
 /* Release the serial peripheral, not currently invoked. It requires further resource management. */

--- a/variants/GD32350G_START/PeripheralPins.c
+++ b/variants/GD32350G_START/PeripheralPins.c
@@ -155,42 +155,42 @@ const PinMap PinMap_UART_TX[] = {
     {PORTB_6,  USART0, GD_PIN_FUNCTION4(PIN_MODE_AF, PIN_OTYPE_PP, PIN_PUPD_PULLUP, GPIO_AF_1)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
     //{PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    // {PORTB_10, USART2, 7},
+    // {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    // {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, GD_PIN_FUNCTION4(PIN_MODE_AF, PIN_OTYPE_PP, PIN_PUPD_PULLUP, GPIO_AF_1)},
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    // {PORTA_3,  USART1, 1},
+    // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    // {PORTB_11, USART2, 1},
+    // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    // {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    // {PORTC_11, UART3, 1},
+    // {PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    // {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    // {PORTB_14, USART2, 7},
+    // {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    // {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    // {PORTB_13, USART2, 7},
+    // {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/GD32350G_START/variant.h
+++ b/variants/GD32350G_START/variant.h
@@ -104,15 +104,26 @@ extern "C" {
 #define PWM4                    PA15
 #define PWM5                    PB15
 
-/* USART definitions */
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
 
-#define SERIAL_HOWMANY          1
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PB7
+#define SERIAL0_TX          PB6
 
-#define USE_USART0_SERIAL	
-#define PIN_SERIAL_RX           PB7
-#define PIN_SERIAL_TX           PB6
-#define SERIAL0_RX          PIN_SERIAL_RX
-#define SERIAL0_TX          PIN_SERIAL_TX
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32E230C4_GENERIC/variant.h
+++ b/variants/GD32E230C4_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32E230C4_GENERIC/variant.h
+++ b/variants/GD32E230C4_GENERIC/variant.h
@@ -107,12 +107,20 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230C6_GENERIC/variant.h
+++ b/variants/GD32E230C6_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230C6_GENERIC/variant.h
+++ b/variants/GD32E230C6_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230C8_GENERIC/variant.h
+++ b/variants/GD32E230C8_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA6
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230C8_GENERIC/variant.h
+++ b/variants/GD32E230C8_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA4
 #define PWM4                        PA6
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230C_START/variant.h
+++ b/variants/GD32E230C_START/variant.h
@@ -111,13 +111,26 @@ extern "C" {
 #define PWM3                        PA4
 #define PWM4                        PA6
 
-/* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
-#define SERIAL0_RX                  PA10
-#define SERIAL0_TX                  PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
+
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230F4_GENERIC/variant.h
+++ b/variants/GD32E230F4_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA10
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32E230F4_GENERIC/variant.h
+++ b/variants/GD32E230F4_GENERIC/variant.h
@@ -83,12 +83,20 @@ extern "C" {
 #define PWM3                        PA9
 #define PWM4                        PA10
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230F6_GENERIC/variant.h
+++ b/variants/GD32E230F6_GENERIC/variant.h
@@ -83,12 +83,29 @@ extern "C" {
 #define PWM3                        PA9
 #define PWM4                        PA10
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230F6_GENERIC/variant.h
+++ b/variants/GD32E230F6_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA10
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230F8_GENERIC/variant.h
+++ b/variants/GD32E230F8_GENERIC/variant.h
@@ -83,12 +83,29 @@ extern "C" {
 #define PWM3                        PA4
 #define PWM4                        PA6
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230F8_GENERIC/variant.h
+++ b/variants/GD32E230F8_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA6
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230G4_GENERIC/variant.h
+++ b/variants/GD32E230G4_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32E230G4_GENERIC/variant.h
+++ b/variants/GD32E230G4_GENERIC/variant.h
@@ -91,12 +91,20 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230G6_GENERIC/variant.h
+++ b/variants/GD32E230G6_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230G6_GENERIC/variant.h
+++ b/variants/GD32E230G6_GENERIC/variant.h
@@ -91,12 +91,29 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230G8_GENERIC/variant.h
+++ b/variants/GD32E230G8_GENERIC/variant.h
@@ -91,12 +91,29 @@ extern "C" {
 #define PWM3                        PA4
 #define PWM4                        PA6
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230G8_GENERIC/variant.h
+++ b/variants/GD32E230G8_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA6
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230K4_GENERIC/variant.h
+++ b/variants/GD32E230K4_GENERIC/variant.h
@@ -94,8 +94,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32E230K4_GENERIC/variant.h
+++ b/variants/GD32E230K4_GENERIC/variant.h
@@ -93,12 +93,20 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230K6_GENERIC/variant.h
+++ b/variants/GD32E230K6_GENERIC/variant.h
@@ -93,12 +93,29 @@ extern "C" {
 #define PWM3                        PA8
 #define PWM4                        PA9
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230K6_GENERIC/variant.h
+++ b/variants/GD32E230K6_GENERIC/variant.h
@@ -94,8 +94,7 @@ extern "C" {
 #define PWM4                        PA9
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E230K8_GENERIC/variant.h
+++ b/variants/GD32E230K8_GENERIC/variant.h
@@ -93,12 +93,29 @@ extern "C" {
 #define PWM3                        PA4
 #define PWM4                        PA6
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32E230K8_GENERIC/variant.h
+++ b/variants/GD32E230K8_GENERIC/variant.h
@@ -94,8 +94,7 @@ extern "C" {
 #define PWM4                        PA6
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32E503C_START/variant.h
+++ b/variants/GD32E503C_START/variant.h
@@ -104,15 +104,26 @@ extern "C" {
 #define PWM4                    PB6
 #define PWM5                    PB7
 
-/* USART definitions */
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
 
-#define SERIAL_HOWMANY          1
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
 
-#define USE_USART0_SERIAL	
-#define PIN_SERIAL_RX           PA10
-#define PIN_SERIAL_TX           PA9
-#define SERIAL0_RX              PIN_SERIAL_RX
-#define SERIAL0_TX              PIN_SERIAL_TX
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32F130C4_GENERIC/variant.h
+++ b/variants/GD32F130C4_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F130C4_GENERIC/variant.h
+++ b/variants/GD32F130C4_GENERIC/variant.h
@@ -107,12 +107,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130C6_GENERIC/variant.h
+++ b/variants/GD32F130C6_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130C6_GENERIC/variant.h
+++ b/variants/GD32F130C6_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130C8_GENERIC/variant.h
+++ b/variants/GD32F130C8_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130C8_GENERIC/variant.h
+++ b/variants/GD32F130C8_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130F4_GENERIC/variant.h
+++ b/variants/GD32F130F4_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F130F4_GENERIC/variant.h
+++ b/variants/GD32F130F4_GENERIC/variant.h
@@ -83,12 +83,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130F6_GENERIC/variant.h
+++ b/variants/GD32F130F6_GENERIC/variant.h
@@ -83,12 +83,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130F6_GENERIC/variant.h
+++ b/variants/GD32F130F6_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130F8_GENERIC/variant.h
+++ b/variants/GD32F130F8_GENERIC/variant.h
@@ -83,12 +83,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130F8_GENERIC/variant.h
+++ b/variants/GD32F130F8_GENERIC/variant.h
@@ -84,8 +84,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130G4_GENERIC/variant.h
+++ b/variants/GD32F130G4_GENERIC/variant.h
@@ -91,12 +91,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130G4_GENERIC/variant.h
+++ b/variants/GD32F130G4_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F130G6_GENERIC/variant.h
+++ b/variants/GD32F130G6_GENERIC/variant.h
@@ -91,12 +91,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130G6_GENERIC/variant.h
+++ b/variants/GD32F130G6_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130G8_GENERIC/variant.h
+++ b/variants/GD32F130G8_GENERIC/variant.h
@@ -91,12 +91,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130G8_GENERIC/variant.h
+++ b/variants/GD32F130G8_GENERIC/variant.h
@@ -92,8 +92,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130K4_GENERIC/variant.h
+++ b/variants/GD32F130K4_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F130K4_GENERIC/variant.h
+++ b/variants/GD32F130K4_GENERIC/variant.h
@@ -95,12 +95,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130K6_GENERIC/variant.h
+++ b/variants/GD32F130K6_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130K6_GENERIC/variant.h
+++ b/variants/GD32F130K6_GENERIC/variant.h
@@ -95,12 +95,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130K8_GENERIC/variant.h
+++ b/variants/GD32F130K8_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F130K8_GENERIC/variant.h
+++ b/variants/GD32F130K8_GENERIC/variant.h
@@ -95,12 +95,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130R8_GENERIC/variant.h
+++ b/variants/GD32F130R8_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F130R8_GENERIC/variant.h
+++ b/variants/GD32F130R8_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150C4_GENERIC/variant.h
+++ b/variants/GD32F150C4_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F150C4_GENERIC/variant.h
+++ b/variants/GD32F150C4_GENERIC/variant.h
@@ -107,12 +107,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150C6_GENERIC/variant.h
+++ b/variants/GD32F150C6_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150C6_GENERIC/variant.h
+++ b/variants/GD32F150C6_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150C8_GENERIC/variant.h
+++ b/variants/GD32F150C8_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150C8_GENERIC/variant.h
+++ b/variants/GD32F150C8_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150G4_GENERIC/variant.h
+++ b/variants/GD32F150G4_GENERIC/variant.h
@@ -93,8 +93,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F150G4_GENERIC/variant.h
+++ b/variants/GD32F150G4_GENERIC/variant.h
@@ -66,7 +66,7 @@ extern "C" {
 #define ANALOG_PINS_LAST            PB1
 
 /* LED definitions */
-#define LED_BUILTIN                 PB2
+#define LED_BUILTIN                 PA4
 
 /* user keys definitions */
 #define KEY0                        PA0
@@ -92,12 +92,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150G6_GENERIC/variant.h
+++ b/variants/GD32F150G6_GENERIC/variant.h
@@ -66,7 +66,7 @@ extern "C" {
 #define ANALOG_PINS_LAST            PB1
 
 /* LED definitions */
-#define LED_BUILTIN                 PB2
+#define LED_BUILTIN                 PA4
 
 /* user keys definitions */
 #define KEY0                        PA0
@@ -92,12 +92,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150G6_GENERIC/variant.h
+++ b/variants/GD32F150G6_GENERIC/variant.h
@@ -93,8 +93,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150G8_GENERIC/variant.h
+++ b/variants/GD32F150G8_GENERIC/variant.h
@@ -66,7 +66,7 @@ extern "C" {
 #define ANALOG_PINS_LAST            PB1
 
 /* LED definitions */
-#define LED_BUILTIN                 PB2
+#define LED_BUILTIN                 PA4
 
 /* user keys definitions */
 #define KEY0                        PA0
@@ -92,12 +92,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150G8_GENERIC/variant.h
+++ b/variants/GD32F150G8_GENERIC/variant.h
@@ -93,8 +93,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150K4_GENERIC/variant.h
+++ b/variants/GD32F150K4_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F150K4_GENERIC/variant.h
+++ b/variants/GD32F150K4_GENERIC/variant.h
@@ -95,12 +95,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150K6_GENERIC/variant.h
+++ b/variants/GD32F150K6_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150K6_GENERIC/variant.h
+++ b/variants/GD32F150K6_GENERIC/variant.h
@@ -95,12 +95,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150K8_GENERIC/variant.h
+++ b/variants/GD32F150K8_GENERIC/variant.h
@@ -96,8 +96,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150K8_GENERIC/variant.h
+++ b/variants/GD32F150K8_GENERIC/variant.h
@@ -95,12 +95,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150R4_GENERIC/variant.h
+++ b/variants/GD32F150R4_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F150R4_GENERIC/variant.h
+++ b/variants/GD32F150R4_GENERIC/variant.h
@@ -123,12 +123,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150R6_GENERIC/variant.h
+++ b/variants/GD32F150R6_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150R6_GENERIC/variant.h
+++ b/variants/GD32F150R6_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F150R8_GENERIC/variant.h
+++ b/variants/GD32F150R8_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F150R8_GENERIC/variant.h
+++ b/variants/GD32F150R8_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F170C4_GENERIC/variant.h
+++ b/variants/GD32F170C4_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F170C4_GENERIC/variant.h
+++ b/variants/GD32F170C4_GENERIC/variant.h
@@ -107,12 +107,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170C6_GENERIC/variant.h
+++ b/variants/GD32F170C6_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F170C6_GENERIC/variant.h
+++ b/variants/GD32F170C6_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170C8_GENERIC/variant.h
+++ b/variants/GD32F170C8_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F170C8_GENERIC/variant.h
+++ b/variants/GD32F170C8_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170R8_GENERIC/variant.h
+++ b/variants/GD32F170R8_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170R8_GENERIC/variant.h
+++ b/variants/GD32F170R8_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F170T4_GENERIC/variant.h
+++ b/variants/GD32F170T4_GENERIC/variant.h
@@ -96,12 +96,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170T4_GENERIC/variant.h
+++ b/variants/GD32F170T4_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F170T6_GENERIC/variant.h
+++ b/variants/GD32F170T6_GENERIC/variant.h
@@ -96,12 +96,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170T6_GENERIC/variant.h
+++ b/variants/GD32F170T6_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F170T8_GENERIC/variant.h
+++ b/variants/GD32F170T8_GENERIC/variant.h
@@ -96,12 +96,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F170T8_GENERIC/variant.h
+++ b/variants/GD32F170T8_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190C4_GENERIC/variant.h
+++ b/variants/GD32F190C4_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F190C4_GENERIC/variant.h
+++ b/variants/GD32F190C4_GENERIC/variant.h
@@ -107,12 +107,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190C6_GENERIC/variant.h
+++ b/variants/GD32F190C6_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190C6_GENERIC/variant.h
+++ b/variants/GD32F190C6_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190C8_GENERIC/variant.h
+++ b/variants/GD32F190C8_GENERIC/variant.h
@@ -108,8 +108,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190C8_GENERIC/variant.h
+++ b/variants/GD32F190C8_GENERIC/variant.h
@@ -107,12 +107,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190R4_GENERIC/variant.h
+++ b/variants/GD32F190R4_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F190R4_GENERIC/variant.h
+++ b/variants/GD32F190R4_GENERIC/variant.h
@@ -123,12 +123,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190R6_GENERIC/variant.h
+++ b/variants/GD32F190R6_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190R6_GENERIC/variant.h
+++ b/variants/GD32F190R6_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190R8_GENERIC/variant.h
+++ b/variants/GD32F190R8_GENERIC/variant.h
@@ -123,12 +123,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190R8_GENERIC/variant.h
+++ b/variants/GD32F190R8_GENERIC/variant.h
@@ -124,8 +124,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190T4_GENERIC/variant.h
+++ b/variants/GD32F190T4_GENERIC/variant.h
@@ -96,12 +96,20 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA3
-#define PIN_SERIAL_TX               PA2
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA3
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190T4_GENERIC/variant.h
+++ b/variants/GD32F190T4_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA3
 #define PIN_SERIAL_TX               PA2
 #define SERIAL0_RX                  PA3

--- a/variants/GD32F190T6_GENERIC/variant.h
+++ b/variants/GD32F190T6_GENERIC/variant.h
@@ -96,12 +96,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190T6_GENERIC/variant.h
+++ b/variants/GD32F190T6_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F190T8_GENERIC/variant.h
+++ b/variants/GD32F190T8_GENERIC/variant.h
@@ -96,12 +96,29 @@ extern "C" {
 #define PWM3                        PA3
 #define PWM4                        PA4
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_INSTANCE 1           
-#define PIN_SERIAL_RX               PA10
-#define PIN_SERIAL_TX               PA9
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE   1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#ifndef SERIAL0_RX
 #define SERIAL0_RX                  PA10
+#endif
+#ifndef SERIAL0_TX
 #define SERIAL0_TX                  PA9
+#endif
+
+/* USART1 */
+#define HAVE_HWSERIAL2
+#ifndef SERIAL1_RX
+#define SERIAL1_RX                  PA3
+#endif
+#ifndef SERIAL1_TX
+#define SERIAL1_TX                  PA2
+#endif
 
 /* ADC definitions */
 #define ADC_RESOLUTION              10

--- a/variants/GD32F190T8_GENERIC/variant.h
+++ b/variants/GD32F190T8_GENERIC/variant.h
@@ -97,8 +97,7 @@ extern "C" {
 #define PWM4                        PA4
 
 /* USART definitions */
-#define SERIAL_HOWMANY              1
-#define USE_USART0_SERIAL           
+#define DEFAULT_HWSERIAL_INSTANCE 1           
 #define PIN_SERIAL_RX               PA10
 #define PIN_SERIAL_TX               PA9
 #define SERIAL0_RX                  PA10

--- a/variants/GD32F303CC_GENERIC/PeripheralPins.c
+++ b/variants/GD32F303CC_GENERIC/PeripheralPins.c
@@ -252,43 +252,43 @@ const PinMap PinMap_UART_TX[] = {
     {PORTA_9,  USART0, 7},
     {PORTB_6,  USART0, 7 | (3 << 3)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
-    //{PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    {PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
+    {PORTB_10, USART2, 7},
+    {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    {PORTA_3,  USART1, 1},
+    {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    {PORTB_11, USART2, 1},
+    {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    //{PORTC_11, UART3, 1},
+    //{PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    {PORTB_14, USART2, 7},
+    {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    {PORTB_13, USART2, 7},
+    {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/GD32F303CC_GENERIC/variant.h
+++ b/variants/GD32F303CC_GENERIC/variant.h
@@ -106,25 +106,26 @@ extern "C" {
 #define PWM4                    PB6
 #define PWM5                    PB7
 
-/* USART definitions */
-
-#define SERIAL_HOWMANY          1
-/* by default now, use PA9 for TX. To get the old behavior for PA3, define the USE_USART1_SERIAL macro. */
-#if !defined(USE_USART0_SERIAL) && !defined(USE_USART1_SERIAL)
-#define USE_USART0_SERIAL
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
 #endif
 
-#ifdef USE_USART0_SERIAL
-#define PIN_SERIAL_RX           PA10
-#define PIN_SERIAL_TX           PA9
-#define SERIAL0_RX          PIN_SERIAL_RX
-#define SERIAL0_TX          PIN_SERIAL_TX
-#elif defined(USE_USART1_SERIAL)
-#define PIN_SERIAL_RX           PA3
-#define PIN_SERIAL_TX           PA2
-#define SERIAL1_RX          PIN_SERIAL_RX
-#define SERIAL1_TX          PIN_SERIAL_TX
-#endif
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
+
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32F303ZE_EVAL/PeripheralPins.c
+++ b/variants/GD32F303ZE_EVAL/PeripheralPins.c
@@ -278,7 +278,7 @@ const PinMap PinMap_UART_TX[] = {
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  USART1, 1},
+    {PORTA_3,  USART1, 1},
     // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
     // {PORTB_11, USART2, 1},
     // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */

--- a/variants/GD32F303ZE_EVAL/PeripheralPins.c
+++ b/variants/GD32F303ZE_EVAL/PeripheralPins.c
@@ -267,42 +267,42 @@ const PinMap PinMap_UART_TX[] = {
     {PORTB_6,  USART0, 7 | (3 << 3)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
     {PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    // {PORTB_10, USART2, 7},
+    // {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    // {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    // {PORTA_3,  USART1, 1},
+    // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    // {PORTB_11, USART2, 1},
+    // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    // {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    // {PORTC_11, UART3, 1},
+    // {PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    // {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    // {PORTB_14, USART2, 7},
+    // {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    // {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    // {PORTB_13, USART2, 7},
+    // {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/GD32F303ZE_EVAL/variant.h
+++ b/variants/GD32F303ZE_EVAL/variant.h
@@ -103,27 +103,14 @@ extern "C" {
 
 /* Serial definitions */
 /* "Serial" is by default Serial1 / USART0 */
-#ifndef DEFAULT_HWSERIAL_IS_USART1
-#define DEFAULT_HWSERIAL_IS_USART1
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
 #endif
 
 /* USART0 */
 #define HAVE_HWSERIAL1
 #define SERIAL0_RX          PA10
 #define SERIAL0_TX          PA9
-
-/* USART1*/
-#define HAVE_HWSERIAL2
-#define SERIAL1_RX          PA3
-#define SERIAL1_TX          PA2
-
-/* USART2 */
-#define HAVE_HWSERIAL3
-#define SERIAL2_RX          PB11
-#define SERIAL2_TX          PB10
-
-
-
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32F303ZE_EVAL/variant.h
+++ b/variants/GD32F303ZE_EVAL/variant.h
@@ -101,13 +101,27 @@ extern "C" {
 #define PWM4                    PA8
 #define PWM5                    PB15
 
-/* USART definitions */
-#define USE_USART1_SERIAL
-#define SERIAL_HOWMANY          1
-#define PIN_SERIAL_RX           PA3
-#define PIN_SERIAL_TX           PA2
-#define SERIAL1_RX          PIN_SERIAL_RX
-#define SERIAL1_TX          PIN_SERIAL_TX
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_IS_USART1
+#define DEFAULT_HWSERIAL_IS_USART1
+#endif
+
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
+
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
+
 
 
 

--- a/variants/GD32F303ZE_EVAL/variant.h
+++ b/variants/GD32F303ZE_EVAL/variant.h
@@ -104,13 +104,13 @@ extern "C" {
 /* Serial definitions */
 /* "Serial" is by default Serial1 / USART0 */
 #ifndef DEFAULT_HWSERIAL_INSTANCE
-#define DEFAULT_HWSERIAL_INSTANCE 1
+#define DEFAULT_HWSERIAL_INSTANCE 2
 #endif
 
 /* USART0 */
-#define HAVE_HWSERIAL1
-#define SERIAL0_RX          PA10
-#define SERIAL0_TX          PA9
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32F307VG_MBED/PeripheralPins.c
+++ b/variants/GD32F307VG_MBED/PeripheralPins.c
@@ -263,42 +263,42 @@ const PinMap PinMap_UART_TX[] = {
     {PORTB_6,  USART0, 7 | (3 << 3)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
     {PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    // {PORTB_10, USART2, 7},
+    // {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    // {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    // {PORTA_3,  USART1, 1},
+    // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    // {PORTB_11, USART2, 1},
+    // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    // {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    // {PORTC_11, UART3, 1},
+    // {PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    // {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    // {PORTB_14, USART2, 7},
+    // {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    // {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    // {PORTB_13, USART2, 7},
+    // {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/GD32F307VG_MBED/PeripheralPins.c
+++ b/variants/GD32F307VG_MBED/PeripheralPins.c
@@ -274,7 +274,7 @@ const PinMap PinMap_UART_TX[] = {
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  USART1, 1},
+    {PORTA_3,  USART1, 1},
     // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
     // {PORTB_11, USART2, 1},
     // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */

--- a/variants/GD32F307VG_MBED/variant.h
+++ b/variants/GD32F307VG_MBED/variant.h
@@ -102,8 +102,7 @@ extern "C" {
 #define PWM5                    PB15
 
 /* USART definitions */
-#define USE_USART1_SERIAL
-#define SERIAL_HOWMANY          1
+#define DEFAULT_HWSERIAL_IS_USART1
 #define PIN_SERIAL_RX           PA3
 #define PIN_SERIAL_TX           PA2
 #define SERIAL1_RX		PIN_SERIAL_RX

--- a/variants/GD32F307VG_MBED/variant.h
+++ b/variants/GD32F307VG_MBED/variant.h
@@ -101,13 +101,16 @@ extern "C" {
 #define PWM4                    PA8
 #define PWM5                    PB15
 
-/* USART definitions */
-#define DEFAULT_HWSERIAL_IS_USART1
-#define PIN_SERIAL_RX           PA3
-#define PIN_SERIAL_TX           PA2
-#define SERIAL1_RX		PIN_SERIAL_RX
-#define SERIAL1_TX		PIN_SERIAL_TX
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
 
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/GD32F307VG_MBED/variant.h
+++ b/variants/GD32F307VG_MBED/variant.h
@@ -104,13 +104,13 @@ extern "C" {
 /* Serial definitions */
 /* "Serial" is by default Serial1 / USART0 */
 #ifndef DEFAULT_HWSERIAL_INSTANCE
-#define DEFAULT_HWSERIAL_INSTANCE 1
+#define DEFAULT_HWSERIAL_INSTANCE 2
 #endif
 
 /* USART0 */
-#define HAVE_HWSERIAL1
-#define SERIAL0_RX          PA10
-#define SERIAL0_TX          PA9
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/WEACT_BLUEPILLPLUS_GD32F303CC/PeripheralPins.c
+++ b/variants/WEACT_BLUEPILLPLUS_GD32F303CC/PeripheralPins.c
@@ -253,42 +253,42 @@ const PinMap PinMap_UART_TX[] = {
     {PORTB_6,  USART0, 7 | (3 << 3)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
     //{PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    // {PORTB_10, USART2, 7},
+    // {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    // {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    // {PORTA_3,  USART1, 1},
+    // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    // {PORTB_11, USART2, 1},
+    // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    // {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    // {PORTC_11, UART3, 1},
+    // {PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    // {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    // {PORTB_14, USART2, 7},
+    // {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    // {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    // {PORTB_13, USART2, 7},
+    // {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
+++ b/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
@@ -104,25 +104,26 @@ extern "C" {
 #define PWM4                    PB6
 #define PWM5                    PB7
 
-/* USART definitions */
-
-#define SERIAL_HOWMANY          1
-/* by default now, use PA9 for TX. To get the old behavior for PA3, define the USE_USART1_SERIAL macro. */
-#if !defined(USE_USART0_SERIAL) && !defined(USE_USART1_SERIAL)
-#define USE_USART0_SERIAL	
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
 #endif
 
-#ifdef USE_USART0_SERIAL	
-#define PIN_SERIAL_RX           PA10
-#define PIN_SERIAL_TX           PA9
-#define SERIAL0_RX          PIN_SERIAL_RX
-#define SERIAL0_TX          PIN_SERIAL_TX
-#elif defined(USE_USART1_SERIAL)
-#define PIN_SERIAL_RX           PA3
-#define PIN_SERIAL_TX           PA2
-#define SERIAL1_RX          PIN_SERIAL_RX
-#define SERIAL1_TX          PIN_SERIAL_TX
-#endif
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
+
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10

--- a/variants/keyboardio_model_100/PeripheralPins.c
+++ b/variants/keyboardio_model_100/PeripheralPins.c
@@ -253,42 +253,42 @@ const PinMap PinMap_UART_TX[] = {
     {PORTB_6,  USART0, 7 | (3 << 3)},   /* GPIO_USART0_TX_REMAP */
     {PORTA_2,  USART1, 7},
     //{PORTD_5,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_TX_REMAP */
-    // {PORTB_10, UART_2, 7},
-    // {PORTC_10, UART_2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
-    // {PORTD_8,  UART_2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
-    // {PORTC_10, UART_3, 7},
-    // {PORTC_12, UART_4, 7},
+    // {PORTB_10, USART2, 7},
+    // {PORTC_10, USART2, 7 | (5 << 3)},   /* GPIO_USART2_TX_PARTIAL_REMAP */
+    // {PORTD_8,  USART2, 7 | (6 << 3)},   /* GPIO_USART2_TX_FULL_REMAP */
+    // {PORTC_10, UART3, 7},
+    // {PORTC_12, UART4, 7},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {PORTA_10, USART0, 1},
     {PORTB_7,  USART0, 1 | (3 << 3)},   /* GPIO_USART0_RX_REMAP */
-    // {PORTA_3,  UART_1, 1},
-    // {PORTD_6,  UART_1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
-    // {PORTB_11, UART_2, 1},
-    // {PORTC_11, UART_2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
-    // {PORTD_9,  UART_2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
-    // {PORTC_11, UART_3, 1},
-    // {PORTD_2,  UART_4, 1},
+    // {PORTA_3,  USART1, 1},
+    // {PORTD_6,  USART1, 1 | (4 << 3)},   /* GPIO_USART1_RX_REMAP */
+    // {PORTB_11, USART2, 1},
+    // {PORTC_11, USART2, 1 | (5 << 3)},   /* GPIO_USART2_RX_PARTIAL_REMAP */
+    // {PORTD_9,  USART2, 1 | (6 << 3)},   /* GPIO_USART2_RX_FULL_REMAP */
+    // {PORTC_11, UART3, 1},
+    // {PORTD_2,  UART4, 1},
     {NC,    NC,     0}
 };
 
 const PinMap PinMap_UART_RTS[] = {
     {PORTA_12, USART0, 7},
     {PORTA_1,  USART1, 7},
-    // {PORTD_4,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
-    // {PORTB_14, UART_2, 7},
-    // {PORTD_12, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
+    // {PORTD_4,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_RTS_REMAP */
+    // {PORTB_14, USART2, 7},
+    // {PORTD_12, USART2, 7 | (6 << 3)},   /* GPIO_USART2_RTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_UART_CTS[] = {
     {PORTA_11, USART0, 7},
     {PORTA_0,  USART1, 7},
-    // {PORTD_3,  UART_1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
-    // {PORTB_13, UART_2, 7},
-    // {PORTD_11, UART_2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
+    // {PORTD_3,  USART1, 7 | (4 << 3)},   /* GPIO_USART1_CTS_REMAP */
+    // {PORTB_13, USART2, 7},
+    // {PORTD_11, USART2, 7 | (6 << 3)},   /* GPIO_USART2_CTS_FULL_REMAP */
     {NC,    NC,    0}
 };
 

--- a/variants/keyboardio_model_100/variant.h
+++ b/variants/keyboardio_model_100/variant.h
@@ -103,15 +103,26 @@ extern "C" {
 #define PWM4                    PA15
 #define PWM5                    PB15
 
-/* USART definitions */
+/* Serial definitions */
+/* "Serial" is by default Serial1 / USART0 */
+#ifndef DEFAULT_HWSERIAL_INSTANCE
+#define DEFAULT_HWSERIAL_INSTANCE 1
+#endif
 
-#define SERIAL_HOWMANY          1
+/* USART0 */
+#define HAVE_HWSERIAL1
+#define SERIAL0_RX          PA10
+#define SERIAL0_TX          PA9
 
-#define USE_USART0_SERIAL       
-#define PIN_SERIAL_RX           PA10
-#define PIN_SERIAL_TX           PA9
-#define SERIAL0_RX          PIN_SERIAL_RX
-#define SERIAL0_TX          PIN_SERIAL_TX
+/* USART1*/
+#define HAVE_HWSERIAL2
+#define SERIAL1_RX          PA3
+#define SERIAL1_TX          PA2
+
+/* USART2 */
+#define HAVE_HWSERIAL3
+#define SERIAL2_RX          PB11
+#define SERIAL2_TX          PB10
 
 
 /* ADC definitions */


### PR DESCRIPTION
* makes all UARTs that the board / chip has available 
   * as `Serial1` through `Serial5` (if existing) 
* `Serial` is a either a macro for `Serial1` (first hardware serial USART0) or for the SerialUSB if the USB CDC is enabled
* Had to place the creation of the Serial objects into their own `.cpp` file because otherwise the linker wouldn't discard them even if the user wasn't using those objects --> waste of RAM. Not the cleanest looking sollution, but it works, without activating LTO which is a whole new rabbit whole
