### PR TITLE
Make all I2C peripherals available

### DIFF
--- a/cores/arduino/gd32/pins_arduino.h
+++ b/cores/arduino/gd32/pins_arduino.h
@@ -52,8 +52,15 @@ static const uint8_t MOSI = PIN_SPI_MOSI;
 static const uint8_t MISO = PIN_SPI_MISO;
 static const uint8_t SCK  = PIN_SPI_SCK;
 
+#ifdef HAVE_I2C
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
+#endif
+
+#ifdef HAVE_I2C1
+static const uint8_t SDA1 = PIN_WIRE1_SDA;
+static const uint8_t SCL1 = PIN_WIRE1_SCL;
+#endif
 
 /* the PIN_SERIAL_TX/RX definitions point to the default Serial's pins */
 #if DEFAULT_HWSERIAL_INSTANCE == 1

--- a/cores/arduino/gd32/pins_arduino.h
+++ b/cores/arduino/gd32/pins_arduino.h
@@ -62,6 +62,11 @@ static const uint8_t SDA1 = PIN_WIRE1_SDA;
 static const uint8_t SCL1 = PIN_WIRE1_SCL;
 #endif
 
+#ifdef HAVE_I2C2
+static const uint8_t SDA2 = PIN_WIRE2_SDA;
+static const uint8_t SCL2 = PIN_WIRE2_SCL;
+#endif
+
 /* the PIN_SERIAL_TX/RX definitions point to the default Serial's pins */
 #if DEFAULT_HWSERIAL_INSTANCE == 1
 #define PIN_SERIAL_RX       SERIAL0_RX

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -40,6 +40,7 @@ TwoWire::TwoWire(uint8_t sda, uint8_t scl, int i2c_index)
 
     _i2c.rx_buffer_ptr = _rx_buffer.buffer;
     _i2c.tx_buffer_ptr = _tx_buffer.buffer;
+    _i2c.tx_rx_buffer_size = (uint16_t) sizeof(_tx_buffer.buffer);
     _i2c.tx_count = 0;
     _i2c.rx_count = 0;
     _i2c.index = i2c_index;

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -112,4 +112,8 @@ extern TwoWire Wire;
 extern TwoWire Wire1;
 #endif
 
+#if defined(HAVE_I2C2)
+extern TwoWire Wire2;
+#endif
+
 #endif

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -41,8 +41,6 @@ typedef struct {
 class TwoWire : public Stream
 {
     private:
-        ring_buffer _rx_buffer = {{0}, 0, 0};;
-        ring_buffer _tx_buffer = {{0}, 0, 0};;
         uint8_t txAddress = 0;
 
 
@@ -51,14 +49,17 @@ class TwoWire : public Stream
         uint8_t ownAddress;
         i2c_t _i2c;
 
+        static void onRequestService(void* pWireObj);
+        static void onReceiveService(void* pWireObj, uint8_t *, int);
+
+    protected:
+        ring_buffer _rx_buffer = {{0}, 0, 0};;
+        ring_buffer _tx_buffer = {{0}, 0, 0};;
         void (*user_onRequest)(void);
         void (*user_onReceive)(int);
-        void onRequestService(void);
-        void onReceiveService(uint8_t *, int);
-
-
 
     public:
+
         TwoWire(uint8_t sda, uint8_t scl, int i2c_index);
 
         void begin();

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -24,9 +24,7 @@
 
 #include "api/Stream.h"
 #include "Arduino.h"
-extern "C" {
 #include "utility/twi.h"
-}
 
 #if !defined(WIRE_BUFFER_LENGTH)
 #define WIRE_BUFFER_LENGTH 32
@@ -43,9 +41,9 @@ typedef struct {
 class TwoWire : public Stream
 {
     private:
-        static ring_buffer _rx_buffer;
-        static ring_buffer _tx_buffer;
-        static uint8_t txAddress;
+        ring_buffer _rx_buffer = {{0}, 0, 0};;
+        ring_buffer _tx_buffer = {{0}, 0, 0};;
+        uint8_t txAddress = 0;
 
 
         uint8_t transmitting;
@@ -53,10 +51,10 @@ class TwoWire : public Stream
         uint8_t ownAddress;
         i2c_t _i2c;
 
-        static void (*user_onRequest)(void);
-        static void (*user_onReceive)(int);
-        static void onRequestService(void);
-        static void onReceiveService(uint8_t *, int);
+        void (*user_onRequest)(void);
+        void (*user_onReceive)(int);
+        void onRequestService(void);
+        void onReceiveService(uint8_t *, int);
 
 
 
@@ -105,14 +103,12 @@ class TwoWire : public Stream
         using Print::write;
 };
 
-#if defined(USE_I2C)
+#if defined(HAVE_I2C)
 extern TwoWire Wire;
-#define HAVE_I2C
 #endif
 
-#if defined(USE_I2C1)
+#if defined(HAVE_I2C1)
 extern TwoWire Wire1;
-#define HAVE_I2C1
 #endif
 
 #endif

--- a/libraries/Wire/src/Wire1.cpp
+++ b/libraries/Wire/src/Wire1.cpp
@@ -1,0 +1,5 @@
+#include "Wire.h"
+
+#if defined(HAVE_I2C1)
+TwoWire Wire1(SDA1, SCL1, 1);
+#endif

--- a/libraries/Wire/src/Wire2.cpp
+++ b/libraries/Wire/src/Wire2.cpp
@@ -1,0 +1,5 @@
+#include "Wire.h"
+
+#if defined(HAVE_I2C2)
+TwoWire Wire2(SDA2, SCL2, 2);
+#endif

--- a/libraries/Wire/src/utility/twi.cpp
+++ b/libraries/Wire/src/utility/twi.cpp
@@ -31,11 +31,6 @@ OF SUCH DAMAGE.
 #include "pinmap.h"
 #include "twi.h"
 
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum {
 #if defined(I2C0)
     I2C0_INDEX,
@@ -492,12 +487,13 @@ i2c_status_enum i2c_wait_standby_state(i2c_t *obj, uint8_t address)
     return status;
 }
 
+#include <functional>
 /** sets function called before a slave read operation
  *
  * @param obj      The I2C object
  * @param function Callback function to use
  */
-void i2c_attach_slave_rx_callback(i2c_t *obj, void (*function)(uint8_t *, int))
+void i2c_attach_slave_rx_callback(i2c_t *obj, std::function<void(uint8_t *, int)> function)
 {
     if (obj == NULL) {
         return;
@@ -514,7 +510,7 @@ void i2c_attach_slave_rx_callback(i2c_t *obj, void (*function)(uint8_t *, int))
  * @param obj      The I2C object
  * @param function Callback function to use
  */
-void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void))
+void i2c_attach_slave_tx_callback(i2c_t *obj, std::function<void(void)> function)
 {
     if (obj == NULL) {
         return;
@@ -572,6 +568,11 @@ i2c_status_enum _i2c_busy_wait(i2c_t *obj)
     return I2C_OK;
 }
 
+void i2c_set_clock(i2c_t *obj, uint32_t clock_hz)
+{
+    i2c_clock_config(obj->i2c, clock_hz, I2C_DTCY_2);
+}
+
 #ifdef I2C0
 /** This function handles I2C interrupt handler
  *
@@ -611,7 +612,7 @@ static void i2c_irq(struct i2c_s *obj_s)
 /** Handle I2C0 event interrupt request
  *
  */
-void I2C0_EV_IRQHandler(void)
+extern "C" void I2C0_EV_IRQHandler(void)
 {
     i2c_irq(obj_s_buf[I2C0_INDEX]);
 }
@@ -619,7 +620,7 @@ void I2C0_EV_IRQHandler(void)
 /** handle I2C0 error interrupt request
  *
  */
-void I2C0_ER_IRQHandler(void)
+extern "C" void I2C0_ER_IRQHandler(void)
 {
     /* no acknowledge received */
     if (i2c_interrupt_flag_get(I2C0, I2C_INT_FLAG_AERR)) {
@@ -663,7 +664,7 @@ void I2C0_ER_IRQHandler(void)
 /** Handle I2C1 event interrupt request
  *
  */
-void I2C1_EV_IRQHandler(void)
+extern "C" void I2C1_EV_IRQHandler(void)
 {
     i2c_irq(obj_s_buf[I2C1_INDEX]);
 }
@@ -671,7 +672,7 @@ void I2C1_EV_IRQHandler(void)
 /** handle I2C1 error interrupt request
  *
  */
-void I2C1_ER_IRQHandler(void)
+extern "C" void I2C1_ER_IRQHandler(void)
 {
     /* no acknowledge received */
     if (i2c_interrupt_flag_get(I2C1, I2C_INT_FLAG_AERR)) {
@@ -709,12 +710,4 @@ void I2C1_ER_IRQHandler(void)
     }
 }
 
-void i2c_set_clock(i2c_t *obj, uint32_t clock_hz)
-{
-    i2c_clock_config(obj->i2c, clock_hz, I2C_DTCY_2);
-}
-
-#endif
-#ifdef __cplusplus
-}
 #endif

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -35,6 +35,7 @@ OF SUCH DAMAGE.
 #include "gd32xxyy.h"
 
 #ifdef __cplusplus
+#include <functional>
 extern "C" {
 #endif
 
@@ -59,8 +60,10 @@ struct i2c_s {
     uint16_t   tx_count;
     uint16_t   rx_count;
 
-    void (*slave_transmit_callback)(void);
-    void (*slave_receive_callback)(uint8_t *, int);
+    std::function<void(void)> slave_transmit_callback;
+    //void (*slave_transmit_callback)(void);
+    std::function<void(uint8_t *, int)> slave_receive_callback;
+    //void (*slave_receive_callback)(uint8_t *, int);
 };
 
 typedef enum {
@@ -86,10 +89,6 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
                                    int stop);
 /* read bytes in master mode at a given address */
 i2c_status_enum i2c_wait_standby_state(i2c_t *obj, uint8_t address);
-/* sets function called before a slave read operation */
-void i2c_attach_slave_rx_callback(i2c_t *obj, void (*function)(uint8_t *, int));
-/* sets function called before a slave write operation */
-void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void));
 /* Write bytes to master */
 i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t size);
 /* set I2C clock speed */
@@ -102,5 +101,10 @@ i2c_status_enum _i2c_busy_wait(i2c_t *obj);
 #ifdef __cplusplus
 }
 #endif
+
+/* sets function called before a slave read operation */
+void i2c_attach_slave_rx_callback(i2c_t *obj, std::function<void(uint8_t *, int)> function);
+/* sets function called before a slave write operation */
+void i2c_attach_slave_tx_callback(i2c_t *obj, std::function<void(void)> function);
 
 #endif /* __TWI_H__ */

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -35,7 +35,6 @@ OF SUCH DAMAGE.
 #include "gd32xxyy.h"
 
 #ifdef __cplusplus
-#include <functional>
 extern "C" {
 #endif
 
@@ -60,10 +59,9 @@ struct i2c_s {
     uint16_t   tx_count;
     uint16_t   rx_count;
 
-    std::function<void(void)> slave_transmit_callback;
-    //void (*slave_transmit_callback)(void);
-    std::function<void(uint8_t *, int)> slave_receive_callback;
-    //void (*slave_receive_callback)(uint8_t *, int);
+    void* pWireObj;
+    void (*slave_transmit_callback)(void* pWireObj);
+    void (*slave_receive_callback)(void* pWireObj, uint8_t *, int);
 };
 
 typedef enum {
@@ -91,6 +89,10 @@ i2c_status_enum i2c_master_receive(i2c_t *obj, uint8_t address, uint8_t *data, u
 i2c_status_enum i2c_wait_standby_state(i2c_t *obj, uint8_t address);
 /* Write bytes to master */
 i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t size);
+/* sets function called before a slave read operation */
+void i2c_attach_slave_rx_callback(i2c_t *obj, void (*function)(void*, uint8_t*, int), void* pWireObj);
+/* sets function called before a slave write operation */
+void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void*), void* pWireObj);
 /* set I2C clock speed */
 void i2c_set_clock(i2c_t *obj, uint32_t clock_hz);
 /* Check to see if the I2C bus is busy */
@@ -101,10 +103,5 @@ i2c_status_enum _i2c_busy_wait(i2c_t *obj);
 #ifdef __cplusplus
 }
 #endif
-
-/* sets function called before a slave read operation */
-void i2c_attach_slave_rx_callback(i2c_t *obj, std::function<void(uint8_t *, int)> function);
-/* sets function called before a slave write operation */
-void i2c_attach_slave_tx_callback(i2c_t *obj, std::function<void(void)> function);
 
 #endif /* __TWI_H__ */

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -38,13 +38,6 @@ OF SUCH DAMAGE.
 extern "C" {
 #endif
 
-/* I2C Tx/Rx buffer size */
-#if !defined(I2C_BUFFER_SIZE)
-#define I2C_BUFFER_SIZE    32
-#elif (I2C_BUFFER_SIZE >= 256)
-#error I2C buffer size cannot exceed 255
-#endif
-
 typedef struct i2c_s i2c_t;
 
 struct i2c_s {
@@ -58,6 +51,8 @@ struct i2c_s {
     uint8_t    *rx_buffer_ptr;
     uint16_t   tx_count;
     uint16_t   rx_count;
+    /* TX and RX buffer are expected to be of this size */
+    uint16_t tx_rx_buffer_size;
 
     void* pWireObj;
     void (*slave_transmit_callback)(void* pWireObj);

--- a/variants/GD32350G_START/variant.h
+++ b/variants/GD32350G_START/variant.h
@@ -132,10 +132,8 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
+#define DAC_RESOLUTION         12
 
-/* I2C definitions */
-#define USE_I2C       1
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/GD32350G_START/variant.h
+++ b/variants/GD32350G_START/variant.h
@@ -89,9 +89,14 @@ extern "C" {
 #define PIN_SPI_MISO            PB14
 #define PIN_SPI_SCK             PB13
 
-/* I2C definitions */
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB9
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB8
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5

--- a/variants/GD32E230C4_GENERIC/variant.h
+++ b/variants/GD32E230C4_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230C6_GENERIC/variant.h
+++ b/variants/GD32E230C6_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230C8_GENERIC/variant.h
+++ b/variants/GD32E230C8_GENERIC/variant.h
@@ -93,9 +93,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA12
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA11
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230C_START/variant.h
+++ b/variants/GD32E230C_START/variant.h
@@ -96,10 +96,14 @@ extern "C" {
 #define PIN_SPI_MISO                PB4
 #define PIN_SPI_SCK                 PB3
 
-/* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230F4_GENERIC/variant.h
+++ b/variants/GD32E230F4_GENERIC/variant.h
@@ -69,9 +69,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PF0
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PF1
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230F6_GENERIC/variant.h
+++ b/variants/GD32E230F6_GENERIC/variant.h
@@ -69,9 +69,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PF0
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PF1
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230F8_GENERIC/variant.h
+++ b/variants/GD32E230F8_GENERIC/variant.h
@@ -69,9 +69,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PF0
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PF1
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230G4_GENERIC/variant.h
+++ b/variants/GD32E230G4_GENERIC/variant.h
@@ -77,9 +77,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230G6_GENERIC/variant.h
+++ b/variants/GD32E230G6_GENERIC/variant.h
@@ -77,9 +77,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230G8_GENERIC/variant.h
+++ b/variants/GD32E230G8_GENERIC/variant.h
@@ -77,9 +77,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230K4_GENERIC/variant.h
+++ b/variants/GD32E230K4_GENERIC/variant.h
@@ -79,9 +79,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230K6_GENERIC/variant.h
+++ b/variants/GD32E230K6_GENERIC/variant.h
@@ -79,9 +79,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E230K8_GENERIC/variant.h
+++ b/variants/GD32E230K8_GENERIC/variant.h
@@ -79,9 +79,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA12
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA11
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32E503C_START/variant.h
+++ b/variants/GD32E503C_START/variant.h
@@ -133,10 +133,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
-
-/* I2C definitions */
-#define USE_I2C       1
+#define DAC_RESOLUTION         12
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/GD32E503C_START/variant.h
+++ b/variants/GD32E503C_START/variant.h
@@ -89,9 +89,15 @@ extern "C" {
 #define PIN_SPI_MISO            PB14
 #define PIN_SPI_SCK             PB13
 
-/* I2C definitions */
-#define PIN_WIRE_SDA            PB11
-#define PIN_WIRE_SCL            PB10
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB11
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB10
+#endif
+
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5

--- a/variants/GD32F130C4_GENERIC/variant.h
+++ b/variants/GD32F130C4_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130C6_GENERIC/variant.h
+++ b/variants/GD32F130C6_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130C8_GENERIC/variant.h
+++ b/variants/GD32F130C8_GENERIC/variant.h
@@ -93,9 +93,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130F4_GENERIC/variant.h
+++ b/variants/GD32F130F4_GENERIC/variant.h
@@ -69,9 +69,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PA10
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PA9
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130F6_GENERIC/variant.h
+++ b/variants/GD32F130F6_GENERIC/variant.h
@@ -69,9 +69,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PA10
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PA9
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130F8_GENERIC/variant.h
+++ b/variants/GD32F130F8_GENERIC/variant.h
@@ -69,9 +69,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PA5
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PA10
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PA9
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130G4_GENERIC/variant.h
+++ b/variants/GD32F130G4_GENERIC/variant.h
@@ -77,9 +77,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130G6_GENERIC/variant.h
+++ b/variants/GD32F130G6_GENERIC/variant.h
@@ -77,9 +77,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130G8_GENERIC/variant.h
+++ b/variants/GD32F130G8_GENERIC/variant.h
@@ -77,9 +77,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130K4_GENERIC/variant.h
+++ b/variants/GD32F130K4_GENERIC/variant.h
@@ -81,9 +81,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130K6_GENERIC/variant.h
+++ b/variants/GD32F130K6_GENERIC/variant.h
@@ -81,9 +81,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130K8_GENERIC/variant.h
+++ b/variants/GD32F130K8_GENERIC/variant.h
@@ -81,9 +81,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F130R8_GENERIC/variant.h
+++ b/variants/GD32F130R8_GENERIC/variant.h
@@ -109,9 +109,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150C4_GENERIC/variant.h
+++ b/variants/GD32F150C4_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150C6_GENERIC/variant.h
+++ b/variants/GD32F150C6_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150C8_GENERIC/variant.h
+++ b/variants/GD32F150C8_GENERIC/variant.h
@@ -93,9 +93,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150G4_GENERIC/variant.h
+++ b/variants/GD32F150G4_GENERIC/variant.h
@@ -78,9 +78,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150G6_GENERIC/variant.h
+++ b/variants/GD32F150G6_GENERIC/variant.h
@@ -78,9 +78,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150G8_GENERIC/variant.h
+++ b/variants/GD32F150G8_GENERIC/variant.h
@@ -78,9 +78,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150K4_GENERIC/variant.h
+++ b/variants/GD32F150K4_GENERIC/variant.h
@@ -81,9 +81,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150K6_GENERIC/variant.h
+++ b/variants/GD32F150K6_GENERIC/variant.h
@@ -81,9 +81,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150K8_GENERIC/variant.h
+++ b/variants/GD32F150K8_GENERIC/variant.h
@@ -81,9 +81,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PA1
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PA0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150R4_GENERIC/variant.h
+++ b/variants/GD32F150R4_GENERIC/variant.h
@@ -109,9 +109,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150R6_GENERIC/variant.h
+++ b/variants/GD32F150R6_GENERIC/variant.h
@@ -109,9 +109,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F150R8_GENERIC/variant.h
+++ b/variants/GD32F150R8_GENERIC/variant.h
@@ -109,9 +109,23 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170C4_GENERIC/variant.h
+++ b/variants/GD32F170C4_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170C6_GENERIC/variant.h
+++ b/variants/GD32F170C6_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170C8_GENERIC/variant.h
+++ b/variants/GD32F170C8_GENERIC/variant.h
@@ -93,9 +93,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PF7
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PF6
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PB7
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PB6
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170R8_GENERIC/variant.h
+++ b/variants/GD32F170R8_GENERIC/variant.h
@@ -109,9 +109,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PF7
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PF6
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PC1
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PC7
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170T4_GENERIC/variant.h
+++ b/variants/GD32F170T4_GENERIC/variant.h
@@ -82,9 +82,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170T6_GENERIC/variant.h
+++ b/variants/GD32F170T6_GENERIC/variant.h
@@ -82,9 +82,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F170T8_GENERIC/variant.h
+++ b/variants/GD32F170T8_GENERIC/variant.h
@@ -82,9 +82,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PF7
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PF6
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PB7
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PB6
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190C4_GENERIC/variant.h
+++ b/variants/GD32F190C4_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190C6_GENERIC/variant.h
+++ b/variants/GD32F190C6_GENERIC/variant.h
@@ -93,9 +93,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190C8_GENERIC/variant.h
+++ b/variants/GD32F190C8_GENERIC/variant.h
@@ -93,9 +93,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PB7
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PB6
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190R4_GENERIC/variant.h
+++ b/variants/GD32F190R4_GENERIC/variant.h
@@ -109,9 +109,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190R6_GENERIC/variant.h
+++ b/variants/GD32F190R6_GENERIC/variant.h
@@ -109,9 +109,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190R8_GENERIC/variant.h
+++ b/variants/GD32F190R8_GENERIC/variant.h
@@ -109,9 +109,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PB11
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PB10
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PC1
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PC0
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190T4_GENERIC/variant.h
+++ b/variants/GD32F190T4_GENERIC/variant.h
@@ -82,9 +82,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190T6_GENERIC/variant.h
+++ b/variants/GD32F190T6_GENERIC/variant.h
@@ -82,9 +82,14 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F190T8_GENERIC/variant.h
+++ b/variants/GD32F190T8_GENERIC/variant.h
@@ -82,9 +82,33 @@ extern "C" {
 #define PIN_SPI_SCK                 PB3
 
 /* I2C definitions */
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
 #define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
 #define PIN_WIRE_SCL                PB6
-#define USE_I2C                     1
+#endif
+
+/* I2C1 */
+#define HAVE_I2C1
+#ifndef PIN_WIRE1_SDA
+#define PIN_WIRE1_SDA               PF7
+#endif
+#ifndef PIN_WIRE1_SCL
+#define PIN_WIRE1_SCL               PF6
+#endif
+
+/* I2C2 */
+/* Pins overlap with I2C0. Change I2C0 pins as neeeded. */
+#define HAVE_I2C2
+#ifndef PIN_WIRE2_SDA
+#define PIN_WIRE2_SDA               PB7
+#endif
+#ifndef PIN_WIRE2_SCL
+#define PIN_WIRE2_SCL               PB6
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE                  TIMER5

--- a/variants/GD32F303CC_GENERIC/variant.h
+++ b/variants/GD32F303CC_GENERIC/variant.h
@@ -92,8 +92,12 @@ extern "C" {
 #define PIN_SPI_SCK             PB13
 
 /* I2C definitions */
+#define HAVE_I2C
 #define PIN_WIRE_SDA            PB9
 #define PIN_WIRE_SCL            PB8
+#define HAVE_I2C1
+#define PIN_WIRE1_SDA           PB11
+#define PIN_WIRE1_SCL           PB10
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5
@@ -130,9 +134,6 @@ extern "C" {
 /* ADC definitions */
 #define ADC_RESOLUTION          10
 #define DACC_RESOLUTION         12
-
-/* I2C definitions */
-#define USE_I2C       1
 
 /* USB definitions */
 #define USB_PULLUP                GPIOA

--- a/variants/GD32F303CC_GENERIC/variant.h
+++ b/variants/GD32F303CC_GENERIC/variant.h
@@ -133,7 +133,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
+#define DAC_RESOLUTION         12
 
 /* USB definitions */
 #define USB_PULLUP                GPIOA

--- a/variants/GD32F303ZE_EVAL/variant.h
+++ b/variants/GD32F303ZE_EVAL/variant.h
@@ -119,10 +119,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
-
-/* I2C definitions */
-#define USE_I2C       1
+#define DAC_RESOLUTION          12
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/GD32F303ZE_EVAL/variant.h
+++ b/variants/GD32F303ZE_EVAL/variant.h
@@ -86,9 +86,14 @@ extern "C" {
 #define PIN_SPI_MISO            PB14
 #define PIN_SPI_SCK             PB13
 
-/* I2C definitions */
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB9
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB8
+#endif
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5

--- a/variants/GD32F307VG_MBED/variant.h
+++ b/variants/GD32F307VG_MBED/variant.h
@@ -86,9 +86,15 @@ extern "C" {
 #define PIN_SPI_MISO            PB14
 #define PIN_SPI_SCK             PB13
 
-/* I2C definitions */
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB9
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB8
+#endif
+
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5

--- a/variants/GD32F307VG_MBED/variant.h
+++ b/variants/GD32F307VG_MBED/variant.h
@@ -120,10 +120,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
-
-/* I2C definitions */
-#define USE_I2C       1
+#define DAC_RESOLUTION         12
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
+++ b/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
@@ -133,10 +133,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
-
-/* I2C definitions */
-#define USE_I2C       1
+#define DAC_RESOLUTION         12
 
 #ifdef __cplusplus
 } // extern "C"

--- a/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
+++ b/variants/WEACT_BLUEPILLPLUS_GD32F303CC/variant.h
@@ -89,9 +89,15 @@ extern "C" {
 #define PIN_SPI_MISO            PB14
 #define PIN_SPI_SCK             PB13
 
-/* I2C definitions */
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB9
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB8
+#endif
+
 
 /* TIMER or PWM definitions */
 #define TIMER_TONE              TIMER5

--- a/variants/keyboardio_model_100/variant.h
+++ b/variants/keyboardio_model_100/variant.h
@@ -127,7 +127,7 @@ extern "C" {
 
 /* ADC definitions */
 #define ADC_RESOLUTION          10
-#define DACC_RESOLUTION         12
+#define DAC_RESOLUTION         12
 
 /* I2C0 */
 #define HAVE_I2C

--- a/variants/keyboardio_model_100/variant.h
+++ b/variants/keyboardio_model_100/variant.h
@@ -129,10 +129,15 @@ extern "C" {
 #define ADC_RESOLUTION          10
 #define DACC_RESOLUTION         12
 
-/* I2C definitions */
-#define USE_I2C       1
-#define PIN_WIRE_SDA            PB7
-#define PIN_WIRE_SCL            PB6
+/* I2C0 */
+#define HAVE_I2C
+#ifndef PIN_WIRE_SDA
+#define PIN_WIRE_SDA                PB7
+#endif
+#ifndef PIN_WIRE_SCL
+#define PIN_WIRE_SCL                PB6
+#endif
+
 
 /* USB definitions */
 #define USB_PULLUP                GPIOA


### PR DESCRIPTION
Exposed as `Wire` (I2C), `Wire1` (I2C1), `Wire2` (I2C2) if available.

Fixes a bug with shared I2C buffers that should never have been shared between instances.

I2C2 often has only one set of pins available, which are our default I2C0 pins. Meaning our default choise for `Wire` (I2C0) with PB6 and PB7 collide with I2C2. Howvever, as I see it, people would then redefine the I2C0 pins so that these become available for I2C2 -- it is more important to keep the "Wire is on PB6 and PB7" default behavior since that is also what the STM32Duino core does. 

Removes USE_I2C(n) macros, uses HAVE_I2C(n) instead. Unused I2C objects are thrown out by the linker.

All pin mappings are redefinable.