### PR TITLE
i2c slave tx now working, see #99

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -299,15 +299,23 @@ void TwoWire::onRequestService(void* pWireObj)
     TwoWire* pWire = (TwoWire*) pWireObj;
     // don't bother if user hasn't registered a callback
     if (pWire->user_onRequest) {
-        // reset tx buffer iterator vars
+        // reset master tx buffer iterator vars
         // !!! this will kill any pending pre-master sendTo() activity
         pWire->_tx_buffer.head = 0;
         pWire->_tx_buffer.tail = 0;
+
+        // reset slave tx buffer iterator vars
+        pWire->_i2c.tx_buffer_ptr = pWire->_tx_buffer.buffer;
+        pWire->_i2c.tx_count = 0;
+
         // alert user program
         pWire->user_onRequest();
-    }
 
+        // reset slave tx buffer iterator to let interrupt transmit the buffer
+        pWire->_i2c.tx_buffer_ptr = pWire->_tx_buffer.buffer;
+    }
 }
+
 // sets function called on slave write
 void TwoWire::onReceive(void (*function)(int))
 {

--- a/libraries/Wire/src/utility/twi.cpp
+++ b/libraries/Wire/src/utility/twi.cpp
@@ -547,10 +547,9 @@ i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t lengt
         return I2C_DATA_TOO_LONG;
 
     uint8_t i = 0;
-    for (i; i < length; i++) {
+    for (i; i < length; i++)
         *obj_s->tx_buffer_ptr++ = *(data + i);
-        obj_s->tx_count += length;
-    }
+    obj_s->tx_count += length;
     return I2C_OK;
 }
 

--- a/libraries/Wire/src/utility/twi.cpp
+++ b/libraries/Wire/src/utility/twi.cpp
@@ -541,17 +541,16 @@ void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void*), void* pWi
  * @param length Number of bytes to read
  * @return status
  */
-ii2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t length)
-{
+i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t length){
     struct i2c_s *obj_s = I2C_S(obj);
-
-    obj_s->tx_count += length;
-    if (obj_s->tx_count > obj->tx_rx_buffer_size) 
+    if (    (obj_s->tx_count + length) > obj->tx_rx_buffer_size) 
         return I2C_DATA_TOO_LONG;
 
     uint8_t i = 0;
-    for (i; i < length; i++) 
+    for (i; i < length; i++) {
         *obj_s->tx_buffer_ptr++ = *(data + i);
+        obj_s->tx_count += length;
+    }
     return I2C_OK;
 }
 

--- a/libraries/Wire/src/utility/twi.cpp
+++ b/libraries/Wire/src/utility/twi.cpp
@@ -541,25 +541,19 @@ void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void*), void* pWi
  * @param length Number of bytes to read
  * @return status
  */
-i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t length)
+ii2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t length)
 {
     struct i2c_s *obj_s = I2C_S(obj);
+
+    obj_s->tx_count += length;
+    if (obj_s->tx_count > obj->tx_rx_buffer_size) 
+        return I2C_DATA_TOO_LONG;
+
     uint8_t i = 0;
-    i2c_status_enum ret = I2C_OK;
-
-    if (length > obj->tx_rx_buffer_size) {
-        ret = I2C_DATA_TOO_LONG;
-    } else {
-        /* check the communication status */
-        for (i = 0; i < length; i++) {
-            *obj_s->tx_buffer_ptr++ = *(data + i);
-        }
-        obj_s->tx_count = length;
-        obj_s->tx_buffer_ptr = obj_s->tx_buffer_ptr - length;
-    }
-    return ret;
+    for (i; i < length; i++) 
+        *obj_s->tx_buffer_ptr++ = *(data + i);
+    return I2C_OK;
 }
-
 
 /** Check the I2C bus to see if it's busy
  *


### PR DESCRIPTION
@maxgerhardt and others :-)
From my [issues/99](https://github.com/CommunityGD32Cores/ArduinoCore-GD32/issues/99):

 Try to get a GD32F130C8 become an i2c slave (SimpleFOC..) but it hangs after several requestEvent() 
...
The buffer pointer gets initialized in the TwoWire constructor [Wire.cpp#L42](https://github.com/CommunityGD32Cores/ArduinoCore-GD32/blob/40cdb8aac306c0adf15f407b58f78bcf56e386b5/libraries/Wire/src/Wire.cpp#L42)
` _i2c.tx_buffer_ptr = _tx_buffer.buffer;`
but is never reset yet incremented when a byte is transmitted in [twi.cpp#L650](https://github.com/CommunityGD32Cores/ArduinoCore-GD32/blob/main/libraries/Wire/src/utility/twi.cpp#L650)
...
As the i2c_slave_tx is done via interrupt in twi.cpp, i could not use the cyclic head/tail method of wire.cpp :-(
So i assume (maybe i am wrong) that while the TwoWire::onRequestService is processed, the I2C interrupt handler i2c_irq(..) of twi.cpp DOES NOT get called (which also uses inrements the tx_buffer_ptr to output the buffer).
Then i can use the tx_buffer_ptr during the onRequestService to fill the buffer, reset it at its end and let the i2c_irq reuse tx_buffer_ptr to output the buffer. 
Then only two changes need to be done :-)

Maybe add this to [Wire/examples/slave_sender/slave_sender.pde](https://github.com/CommunityGD32Cores/ArduinoCore-GD32/blob/main/libraries/Wire/examples/slave_sender/slave_sender.pde):
`// The tx buffer is only 32 bytes long. To send bigger structs one must #define WIRE_BUFFER_LENGTH 128 before #include <Wire.h>`

Greetings from Germany, Roland and :-)