### PR TITLE
typo trasnmit -> transmit

### DIFF
--- a/system/GD32E50x_firmware/GD32E50x_standard_peripheral/Include/gd32e50x_can.h
+++ b/system/GD32E50x_firmware/GD32E50x_standard_peripheral/Include/gd32e50x_can.h
@@ -493,7 +493,7 @@ typedef struct
     uint8_t fd_flag;                                                    /*!< CAN FD frame flag */
     uint8_t fd_brs;                                                     /*!< bit rate of data switch */
     uint8_t fd_esi;                                                     /*!< error status indicator */
-}can_trasnmit_message_struct;
+}can_transmit_message_struct;
 
 /* CAN receive message struct */
 typedef struct
@@ -519,7 +519,7 @@ typedef struct
     uint8_t tx_ft;                                                      /*!< type of frame, data or remote */
     uint8_t tx_dlen;                                                    /*!< data length */
     uint8_t tx_data[8];                                                 /*!< transmit data */
-}can_trasnmit_message_struct;
+}can_transmit_message_struct;
 
 /* CAN receive message struct */
 typedef struct
@@ -883,7 +883,7 @@ void can_time_trigger_mode_enable(uint32_t can_periph);
 void can_time_trigger_mode_disable(uint32_t can_periph);
 
 /* transmit CAN message */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message);
+uint8_t can_message_transmit(uint32_t can_periph, can_transmit_message_struct* transmit_message);
 /* get CAN transmit state */
 can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox_number);
 /* stop CAN transmission */

--- a/system/GD32E50x_firmware/GD32E50x_standard_peripheral/Source/gd32e50x_can.c
+++ b/system/GD32E50x_firmware/GD32E50x_standard_peripheral/Source/gd32e50x_can.c
@@ -207,19 +207,19 @@ void can_struct_para_init(can_struct_type_enum type, void* p_struct)
             break;
         /* used for can_message_transmit() */
         case CAN_TX_MESSAGE_STRUCT:
-            ((can_trasnmit_message_struct*)p_struct)->fd_brs = CAN_BRS_DISABLE;
-            ((can_trasnmit_message_struct*)p_struct)->fd_esi = CAN_ESI_DOMINANT;
-            ((can_trasnmit_message_struct*)p_struct)->fd_flag = CAN_FDF_CLASSIC;
+            ((can_transmit_message_struct*)p_struct)->fd_brs = CAN_BRS_DISABLE;
+            ((can_transmit_message_struct*)p_struct)->fd_esi = CAN_ESI_DOMINANT;
+            ((can_transmit_message_struct*)p_struct)->fd_flag = CAN_FDF_CLASSIC;
 
             for(i = 0U; i < 64U; i++){
-                ((can_trasnmit_message_struct*)p_struct)->tx_data[i] = 0U;
+                ((can_transmit_message_struct*)p_struct)->tx_data[i] = 0U;
             }
 
-            ((can_trasnmit_message_struct*)p_struct)->tx_dlen = 0u;
-            ((can_trasnmit_message_struct*)p_struct)->tx_efid = 0U;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_trasnmit_message_struct*)p_struct)->tx_sfid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_dlen = 0u;
+            ((can_transmit_message_struct*)p_struct)->tx_efid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+            ((can_transmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+            ((can_transmit_message_struct*)p_struct)->tx_sfid = 0U;
 
             break;
         /* used for can_message_receive() */
@@ -244,14 +244,14 @@ void can_struct_para_init(can_struct_type_enum type, void* p_struct)
         /* used for can_message_transmit() */
         case CAN_TX_MESSAGE_STRUCT:
             for(i = 0U; i < 8U; i++){
-                ((can_trasnmit_message_struct*)p_struct)->tx_data[i] = 0U;
+                ((can_transmit_message_struct*)p_struct)->tx_data[i] = 0U;
             }
             
-            ((can_trasnmit_message_struct*)p_struct)->tx_dlen = 0u;
-            ((can_trasnmit_message_struct*)p_struct)->tx_efid = 0U;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_trasnmit_message_struct*)p_struct)->tx_sfid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_dlen = 0u;
+            ((can_transmit_message_struct*)p_struct)->tx_efid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+            ((can_transmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+            ((can_transmit_message_struct*)p_struct)->tx_sfid = 0U;
             
             break;
         /* used for can_message_receive() */
@@ -997,7 +997,7 @@ void can_time_trigger_mode_disable(uint32_t can_periph)
     \param[out] none
     \retval     mailbox_number
 */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message)
+uint8_t can_message_transmit(uint32_t can_periph, can_transmit_message_struct* transmit_message)
 {
     uint8_t mailbox_number = CAN_MAILBOX0;
     volatile uint32_t p_temp;

--- a/system/GD32F30x_firmware/GD32F30x_standard_peripheral/Include/gd32f30x_can.h
+++ b/system/GD32F30x_firmware/GD32F30x_standard_peripheral/Include/gd32f30x_can.h
@@ -423,7 +423,7 @@ typedef struct
     uint8_t tx_ft;                                                      /*!< type of frame, data or remote */
     uint8_t tx_dlen;                                                    /*!< data length */
     uint8_t tx_data[8];                                                 /*!< transmit data */
-}can_trasnmit_message_struct;
+}can_transmit_message_struct;
 
 /* CAN receive message struct */
 typedef struct
@@ -715,7 +715,7 @@ void can_time_trigger_mode_disable(uint32_t can_periph);
 
 /* transmit functions */
 /* transmit CAN message */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message);
+uint8_t can_message_transmit(uint32_t can_periph, can_transmit_message_struct* transmit_message);
 /* get CAN transmit state */
 can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox_number);
 /* stop CAN transmission */

--- a/system/GD32F30x_firmware/GD32F30x_standard_peripheral/Source/gd32f30x_can.c
+++ b/system/GD32F30x_firmware/GD32F30x_standard_peripheral/Source/gd32f30x_can.c
@@ -121,14 +121,14 @@ void can_struct_para_init(can_struct_type_enum type, void* p_struct)
         /* used for can_message_transmit() */
         case CAN_TX_MESSAGE_STRUCT:
             for(i = 0U; i < 8U; i++){
-                ((can_trasnmit_message_struct*)p_struct)->tx_data[i] = 0U;
+                ((can_transmit_message_struct*)p_struct)->tx_data[i] = 0U;
             }
             
-            ((can_trasnmit_message_struct*)p_struct)->tx_dlen = 0u;
-            ((can_trasnmit_message_struct*)p_struct)->tx_efid = 0U;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_trasnmit_message_struct*)p_struct)->tx_sfid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_dlen = 0u;
+            ((can_transmit_message_struct*)p_struct)->tx_efid = 0U;
+            ((can_transmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+            ((can_transmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+            ((can_transmit_message_struct*)p_struct)->tx_sfid = 0U;
             
             break;
         /* used for can_message_receive() */
@@ -442,7 +442,7 @@ void can_time_trigger_mode_disable(uint32_t can_periph)
     \param[out] none
     \retval     mailbox_number
 */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message)
+uint8_t can_message_transmit(uint32_t can_periph, can_transmit_message_struct* transmit_message)
 {
     uint8_t mailbox_number = CAN_MAILBOX0;
 


### PR DESCRIPTION
There is a typo in the struct 
```
can_trasnmit_message_struct
```
It should be:
```
can_transmit_message_struct
```
As this is a key struct it should be changed before it is used too much by peoply like me :)
