### PR TITLE
SPI fix for MSB code

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -114,11 +114,11 @@ uint16_t SPIClass::transfer16(uint16_t val16)
     if (spisettings.bitorder == LSBFIRST) {
         rec_data0 = transfer(trans_data0);
         rec_data1 = transfer(trans_data1);
-        out_halfword = uint16_t(rec_data0 || rec_data1 << 8);
+        out_halfword = uint16_t(rec_data0 | (rec_data1 << 8));
     } else {
         rec_data0 = transfer(trans_data1);
         rec_data1 = transfer(trans_data0);
-        out_halfword = uint16_t(rec_data1 || rec_data0 << 8);
+        out_halfword = uint16_t(rec_data1 | (rec_data0 << 8));
     }
 
     return out_halfword;


### PR DESCRIPTION
There were two incorrect uses of "||" (or) that could have been "|" (bitwise OR) for MSB operation.