### PR TITLE
Fix 2 "statement has no effect" warnings

### DIFF
--- a/libraries/Wire/src/utility/twi.cpp
+++ b/libraries/Wire/src/utility/twi.cpp
@@ -513,7 +513,7 @@ void i2c_attach_slave_rx_callback(i2c_t *obj, void (*function)(void*, uint8_t*, 
         return;
     }
     obj->slave_receive_callback = function;
-    obj->pWireObj;
+    obj->pWireObj= pWireObj;
 }
 
 /** sets function called before a slave write operation
@@ -546,8 +546,7 @@ i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t lengt
     if (    (obj_s->tx_count + length) > obj->tx_rx_buffer_size) 
         return I2C_DATA_TOO_LONG;
 
-    uint8_t i = 0;
-    for (i; i < length; i++)
+    for (uint8_t i = 0; i < length; i++)
         *obj_s->tx_buffer_ptr++ = *(data + i);
     obj_s->tx_count += length;
     return I2C_OK;


### PR DESCRIPTION
2 cases where there were statements without effect, likely typos.  This fixes both.